### PR TITLE
Hyprbars: Improve Title Rendering 

### DIFF
--- a/hyprbars/Makefile
+++ b/hyprbars/Makefile
@@ -13,3 +13,9 @@ $(TARGET): $(SRC)
 
 clean:
 	rm ./$(TARGET)
+
+meson-build:
+	mkdir -p build
+	cd build && meson .. && ninja
+
+.PHONY: all meson-build clean

--- a/hyprbars/Makefile
+++ b/hyprbars/Makefile
@@ -1,4 +1,15 @@
-all:
-	g++ -shared -fPIC --no-gnu-unique main.cpp barDeco.cpp -o hyprbars.so -g -I "/usr/include/pixman-1" -I "/usr/include/libdrm" $(shell pkg-config --cflags hyprland) -std=c++23
+CXX = g++
+CXXFLAGS = -shared -fPIC --no-gnu-unique -g -std=c++23
+INCLUDES = -I "/usr/include/pixman-1" -I "/usr/include/libdrm" -I $(shell pkg-config --cflags hyprland pangocairo)
+LIBS = $(shell pkg-config --libs pangocairo)
+
+SRC = main.cpp barDeco.cpp
+TARGET = hyprbars.so
+
+all: $(TARGET)
+
+$(TARGET): $(SRC)
+	$(CXX) $(CXXFLAGS) $(INCLUDES) $^ -o $@ $(LIBS)
+
 clean:
-	rm ./hyprbars.so
+	rm ./$(TARGET)

--- a/hyprbars/README.md
+++ b/hyprbars/README.md
@@ -25,3 +25,7 @@ plugin {
 `bar_text_size` -> (int) bar's title text font size (default 10)
 
 `bar_text_font` -> (str) bar's title text font (default "Sans")
+
+`button_max_color` -> (col) maximize button color
+
+`button_close_color` -> (col) close button color

--- a/hyprbars/README.md
+++ b/hyprbars/README.md
@@ -31,6 +31,8 @@ plugin {
 
 ## Buttons Config
 
+`button_size` -> (int) the size of the buttons.
+
 `col.maximize` -> (col) maximize button color
 
 `col.close` -> (col) close button color

--- a/hyprbars/README.md
+++ b/hyprbars/README.md
@@ -12,6 +12,9 @@ All config options are in `plugin:hyprbars`:
 plugin {
     hyprbars {
         # config
+        buttons {
+            # button config
+        }
     }
 }
 ```
@@ -20,12 +23,14 @@ plugin {
 
 `bar_height` -> (int) bar's height (default 15)
 
-`bar_text_color` -> (col) bar's title text color
+`col.text` -> (col) bar's title text color
 
 `bar_text_size` -> (int) bar's title text font size (default 10)
 
 `bar_text_font` -> (str) bar's title text font (default "Sans")
 
-`button_max_color` -> (col) maximize button color
+## Buttons Config
 
-`button_close_color` -> (col) close button color
+`col.maximize` -> (col) maximize button color
+
+`col.close` -> (col) close button color

--- a/hyprbars/barDeco.cpp
+++ b/hyprbars/barDeco.cpp
@@ -116,8 +116,9 @@ void CHyprBar::renderBarTitle(const Vector2D& bufferSize) {
     const CColor       COLOR = *PCOLOR;
 
     const auto         CAIROSURFACE = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, bufferSize.x, bufferSize.y);
+    const auto         CAIRO        = cairo_create(CAIROSURFACE);
 
-    const auto         CAIRO = cairo_create(CAIROSURFACE);
+    const int          BAR_PADDING = 10;
 
     // clear the pixmap
     cairo_save(CAIRO);
@@ -134,12 +135,20 @@ void CHyprBar::renderBarTitle(const Vector2D& bufferSize) {
     pango_layout_set_font_description(layout, font_desc);
     pango_font_description_free(font_desc);
 
+    const int left_padding  = BAR_PADDING;
+    const int right_padding = BUTTONS_SIZE * 5 + BUTTONS_PAD * 2 + (BAR_PADDING);
+    const int max_width     = bufferSize.x - left_padding - right_padding;
+
+    pango_layout_set_width(layout, max_width * PANGO_SCALE);
+    pango_layout_set_ellipsize(layout, PANGO_ELLIPSIZE_END);
+
     cairo_set_source_rgba(CAIRO, COLOR.r, COLOR.g, COLOR.b, COLOR.a);
 
     int layout_width, layout_height;
     pango_layout_get_size(layout, &layout_width, &layout_height);
-    auto x_offset = std::round((bufferSize.x / 2.0 - layout_width / PANGO_SCALE / 2.0));
-    auto y_offset = std::round((bufferSize.y / 2.0 - layout_height / PANGO_SCALE / 2.0));
+    const int x_offset = std::round((bufferSize.x / 2.0 - layout_width / PANGO_SCALE / 2.0));
+    const int y_offset = std::round((bufferSize.y / 2.0 - layout_height / PANGO_SCALE / 2.0));
+
     cairo_move_to(CAIRO, x_offset, y_offset);
     pango_cairo_show_layout(CAIRO, layout);
 

--- a/hyprbars/barDeco.cpp
+++ b/hyprbars/barDeco.cpp
@@ -109,7 +109,7 @@ void CHyprBar::onMouseMove(Vector2D coords) {
 }
 
 void CHyprBar::renderBarTitle(const Vector2D& bufferSize) {
-    static auto* const PCOLOR = &HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_text_color")->intValue;
+    static auto* const PCOLOR = &HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:col.text")->intValue;
     static auto* const PSIZE  = &HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_text_size")->intValue;
     static auto* const PFONT  = &HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_text_font")->strValue;
 
@@ -118,7 +118,7 @@ void CHyprBar::renderBarTitle(const Vector2D& bufferSize) {
     const auto         CAIROSURFACE = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, bufferSize.x, bufferSize.y);
     const auto         CAIRO        = cairo_create(CAIROSURFACE);
 
-    const int          BAR_PADDING = 10;
+    const int          BARPADDING = 10;
 
     // clear the pixmap
     cairo_save(CAIRO);
@@ -130,26 +130,26 @@ void CHyprBar::renderBarTitle(const Vector2D& bufferSize) {
     PangoLayout* layout = pango_cairo_create_layout(CAIRO);
     pango_layout_set_text(layout, m_szLastTitle.c_str(), -1);
 
-    PangoFontDescription* font_desc = pango_font_description_from_string(PFONT->c_str());
-    pango_font_description_set_size(font_desc, *PSIZE * PANGO_SCALE);
-    pango_layout_set_font_description(layout, font_desc);
-    pango_font_description_free(font_desc);
+    PangoFontDescription* fontDesc = pango_font_description_from_string(PFONT->c_str());
+    pango_font_description_set_size(fontDesc, *PSIZE * PANGO_SCALE);
+    pango_layout_set_font_description(layout, fontDesc);
+    pango_font_description_free(fontDesc);
 
-    const int left_padding  = BAR_PADDING;
-    const int right_padding = BUTTONS_SIZE * 5 + BUTTONS_PAD * 2 + (BAR_PADDING);
-    const int max_width     = bufferSize.x - left_padding - right_padding;
+    const int leftPadding  = BARPADDING;
+    const int rightPadding = BUTTONS_SIZE * 5 + BUTTONS_PAD * 2 + (BARPADDING);
+    const int maxWidth     = bufferSize.x - leftPadding - rightPadding;
 
-    pango_layout_set_width(layout, max_width * PANGO_SCALE);
+    pango_layout_set_width(layout, maxWidth * PANGO_SCALE);
     pango_layout_set_ellipsize(layout, PANGO_ELLIPSIZE_END);
 
     cairo_set_source_rgba(CAIRO, COLOR.r, COLOR.g, COLOR.b, COLOR.a);
 
-    int layout_width, layout_height;
-    pango_layout_get_size(layout, &layout_width, &layout_height);
-    const int x_offset = std::round((bufferSize.x / 2.0 - layout_width / PANGO_SCALE / 2.0));
-    const int y_offset = std::round((bufferSize.y / 2.0 - layout_height / PANGO_SCALE / 2.0));
+    int layoutWidth, layoutHeight;
+    pango_layout_get_size(layout, &layoutWidth, &layoutHeight);
+    const int xOffset = std::round((bufferSize.x / 2.0 - layoutWidth / PANGO_SCALE / 2.0));
+    const int yOffset = std::round((bufferSize.y / 2.0 - layoutHeight / PANGO_SCALE / 2.0));
 
-    cairo_move_to(CAIRO, x_offset, y_offset);
+    cairo_move_to(CAIRO, xOffset, yOffset);
     pango_cairo_show_layout(CAIRO, layout);
 
     g_object_unref(layout);
@@ -176,11 +176,11 @@ void CHyprBar::renderBarTitle(const Vector2D& bufferSize) {
 }
 
 void CHyprBar::renderBarButtons(const Vector2D& bufferSize) {
-    static const int CLOSE_COLOR = HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:button_close_color")->intValue;
-    static const int MAX_COLOR   = HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:button_max_color")->intValue;
+    static auto* const PCLOSECOLOR = &HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:buttons:col.close")->intValue;
+    static auto* const PMAXCOLOR   = &HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:buttons:col.maximize")->intValue;
 
-    const auto       CAIROSURFACE = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, bufferSize.x, bufferSize.y);
-    const auto       CAIRO        = cairo_create(CAIROSURFACE);
+    const auto         CAIROSURFACE = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, bufferSize.x, bufferSize.y);
+    const auto         CAIRO        = cairo_create(CAIROSURFACE);
 
     // clear the pixmap
     cairo_save(CAIRO);
@@ -204,11 +204,11 @@ void CHyprBar::renderBarButtons(const Vector2D& bufferSize) {
 
     Vector2D currentPos = Vector2D{bufferSize.x - BUTTONS_PAD - BUTTONS_SIZE, bufferSize.y / 2.0 - BUTTONS_SIZE / 2.0}.floor();
 
-    drawButton(currentPos, CColor(CLOSE_COLOR));
+    drawButton(currentPos, CColor(*PCLOSECOLOR));
 
     currentPos.x -= BUTTONS_PAD + BUTTONS_SIZE;
 
-    drawButton(currentPos, CColor(MAX_COLOR));
+    drawButton(currentPos, CColor(*PMAXCOLOR));
 
     // copy the data to an OpenGL texture we have
     const auto DATA = cairo_image_surface_get_data(CAIROSURFACE);

--- a/hyprbars/barDeco.cpp
+++ b/hyprbars/barDeco.cpp
@@ -176,9 +176,11 @@ void CHyprBar::renderBarTitle(const Vector2D& bufferSize) {
 }
 
 void CHyprBar::renderBarButtons(const Vector2D& bufferSize) {
+    static const int CLOSE_COLOR = HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:button_close_color")->intValue;
+    static const int MAX_COLOR   = HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:button_max_color")->intValue;
 
-    const auto CAIROSURFACE = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, bufferSize.x, bufferSize.y);
-    const auto CAIRO        = cairo_create(CAIROSURFACE);
+    const auto       CAIROSURFACE = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, bufferSize.x, bufferSize.y);
+    const auto       CAIRO        = cairo_create(CAIROSURFACE);
 
     // clear the pixmap
     cairo_save(CAIRO);
@@ -202,11 +204,11 @@ void CHyprBar::renderBarButtons(const Vector2D& bufferSize) {
 
     Vector2D currentPos = Vector2D{bufferSize.x - BUTTONS_PAD - BUTTONS_SIZE, bufferSize.y / 2.0 - BUTTONS_SIZE / 2.0}.floor();
 
-    drawButton(currentPos, CColor{1.0, 0.0, 0.0, 0.8});
+    drawButton(currentPos, CColor(CLOSE_COLOR));
 
     currentPos.x -= BUTTONS_PAD + BUTTONS_SIZE;
 
-    drawButton(currentPos, CColor{0.9, 0.9, 0.1, 0.8});
+    drawButton(currentPos, CColor(MAX_COLOR));
 
     // copy the data to an OpenGL texture we have
     const auto DATA = cairo_image_surface_get_data(CAIROSURFACE);

--- a/hyprbars/main.cpp
+++ b/hyprbars/main.cpp
@@ -34,6 +34,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_text_font", SConfigValue{.strValue = "Sans"});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:buttons:col.close", SConfigValue{.intValue = configStringToInt("rgba(cc0000cc)")});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:buttons:col.maximize", SConfigValue{.intValue = configStringToInt("rgba(ffff33cc)")});
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:buttons:button_size", SConfigValue{.intValue = 10});
 
     // add deco to existing windows
     for (auto& w : g_pCompositor->m_vWindows) {

--- a/hyprbars/main.cpp
+++ b/hyprbars/main.cpp
@@ -29,11 +29,11 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_color", SConfigValue{.intValue = configStringToInt("rgba(33333388)")});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_height", SConfigValue{.intValue = 15});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_text_color", SConfigValue{.intValue = configStringToInt("rgba(ffffffff)")});
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:col.text", SConfigValue{.intValue = configStringToInt("rgba(ffffffff)")});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_text_size", SConfigValue{.intValue = 10});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_text_font", SConfigValue{.strValue = "Sans"});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:button_close_color", SConfigValue{.intValue = configStringToInt("rgba(cc0000cc)")});
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:button_max_color", SConfigValue{.intValue = configStringToInt("rgba(ffff33cc)")});
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:buttons:col.close", SConfigValue{.intValue = configStringToInt("rgba(cc0000cc)")});
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:buttons:col.maximize", SConfigValue{.intValue = configStringToInt("rgba(ffff33cc)")});
 
     // add deco to existing windows
     for (auto& w : g_pCompositor->m_vWindows) {

--- a/hyprbars/main.cpp
+++ b/hyprbars/main.cpp
@@ -32,6 +32,8 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_text_color", SConfigValue{.intValue = configStringToInt("rgba(ffffffff)")});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_text_size", SConfigValue{.intValue = 10});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_text_font", SConfigValue{.strValue = "Sans"});
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:button_close_color", SConfigValue{.intValue = configStringToInt("rgba(cc0000cc)")});
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:button_max_color", SConfigValue{.intValue = configStringToInt("rgba(ffff33cc)")});
 
     // add deco to existing windows
     for (auto& w : g_pCompositor->m_vWindows) {

--- a/hyprbars/meson.build
+++ b/hyprbars/meson.build
@@ -22,6 +22,7 @@ shared_module(meson.project_name(), src,
     dependency('hyprland'),
     dependency('pixman-1'),
     dependency('libdrm'),
+    dependency('pangocairo')
   ],
   install: true,
 )


### PR DESCRIPTION
# Changes 
- use pangocairo to draw title: recommend way to render text.
- adds title padding and prevents title from overlapping with buttons: closes #7 
- If title is too long shorten it with an ellipsis
- add close and maximize colors to the config options

# Comments 
Don't code in C++ so I'm not sure how to best include `pangocairo.h` or how to update the meson.build. Not even sure how cario is already being included.  