### PR TITLE
Unbreak build with Clang

### DIFF
--- a/borders-plus-plus/Makefile
+++ b/borders-plus-plus/Makefile
@@ -1,4 +1,4 @@
 all:
-	$(CXX) -shared -fPIC --no-gnu-unique main.cpp borderDeco.cpp -o borders-plus-plus.so -g `pkg-config --cflags pixman-1 libdrm hyprland` -std=c++2b
+	$(CXX) -shared -fPIC main.cpp borderDeco.cpp -o borders-plus-plus.so -g `pkg-config --cflags pixman-1 libdrm hyprland` -std=c++2b
 clean:
 	rm ./borders-plus-plus.so

--- a/csgo-vulkan-fix/Makefile
+++ b/csgo-vulkan-fix/Makefile
@@ -1,4 +1,4 @@
 all:
-	$(CXX) -shared -fPIC --no-gnu-unique main.cpp -o csgo-vulkan-fix.so -g `pkg-config --cflags pixman-1 libdrm hyprland` -std=c++2b
+	$(CXX) -shared -fPIC main.cpp -o csgo-vulkan-fix.so -g `pkg-config --cflags pixman-1 libdrm hyprland` -std=c++2b
 clean:
 	rm ./csgo-vulkan-fix.so

--- a/hyprbars/Makefile
+++ b/hyprbars/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS = -shared -fPIC --no-gnu-unique -g -std=c++2b -Wno-c++11-narrowing
+CXXFLAGS = -shared -fPIC -g -std=c++2b -Wno-c++11-narrowing
 INCLUDES = `pkg-config --cflags pixman-1 libdrm hyprland pangocairo`
 LIBS = `pkg-config --libs pangocairo`
 


### PR DESCRIPTION
Only [Gold](https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff;h=9634ed06a66c369) and [LLD](https://github.com/llvm/llvm-project/commit/87b0d68633af) have `--no-gnu-unique`. GCC defaults to `-fuse-ld=bfd`, so `--no-gnu-unique` as compiler flag is simply discarded unless GCC itself was built with `--disable-gnu-unique-object` in which case `--no-gnu-unique` becomes default. Clang doesn't have such magic, so `--no-gnu-unique` fails because it's not supported by the compiler unlike `-Wl,--no-gnu-unique` which is passed to the linker.
