### PR TITLE
Use `pname` instead of `name` for plugin derivations

### DIFF
--- a/borders-plus-plus/default.nix
+++ b/borders-plus-plus/default.nix
@@ -4,7 +4,7 @@
   hyprland,
 }:
 stdenv.mkDerivation {
-  name = "borders-plus-plus";
+  pname = "borders-plus-plus";
   version = "0.1";
   src = ./.;
 

--- a/csgo-vulkan-fix/default.nix
+++ b/csgo-vulkan-fix/default.nix
@@ -4,7 +4,7 @@
   hyprland,
 }:
 stdenv.mkDerivation {
-  name = "csgo-vulkan-fix";
+  pname = "csgo-vulkan-fix";
   version = "0.1";
   src = ./.;
 

--- a/hyprbars/default.nix
+++ b/hyprbars/default.nix
@@ -4,7 +4,7 @@
   hyprland,
 }:
 stdenv.mkDerivation {
-  name = "hyprbars";
+  pname = "hyprbars";
   version = "0.1";
   src = ./.;
 


### PR DESCRIPTION
Use `pname` in place of `name` for plugin derivations. This makes `name` equal `${pname}-${version}`. This lets the hyprland flake locate plugin artifacts using `pname` (it does not use `name` because the derivation name often contains a version).

I have tested that all plugins are able to be loaded with this pr.

(@fufexan)