### PR TITLE
nix: expose winwrap via flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,10 @@
         inherit (hyprland.packages.${system}) hyprland;
         stdenv = pkgs.gcc13Stdenv;
       };
+      hyprwinwrap = pkgs.callPackage ./hyprwinwrap {
+        inherit (hyprland.packages.${system}) hyprland;
+        stdenv = pkgs.gcc13Stdenv;
+      };
     });
 
     devShells = withPkgsFor (system: pkgs: {


### PR DESCRIPTION
To make it easier for people using nix flakes to consume it.
