### PR TITLE
Update pkgconfig flags of hyprbars to include irregular locations of headers on distros like openSUSE

### DIFF
--- a/hyprbars/Makefile
+++ b/hyprbars/Makefile
@@ -1,5 +1,5 @@
 CXXFLAGS = -shared -fPIC --no-gnu-unique -g -std=c++2b -Wno-c++11-narrowing
-INCLUDES = `pkg-config --cflags pixman-1 libdrm hyprland pangocairo`
+INCLUDES = `pkg-config --cflags pixman-1 libdrm hyprland pangocairo libinput libudev wayland-server hyprland`
 LIBS = `pkg-config --libs pangocairo`
 
 SRC = main.cpp barDeco.cpp

--- a/hyprbars/meson.build
+++ b/hyprbars/meson.build
@@ -28,7 +28,10 @@ shared_module(meson.project_name(), src,
     dependency('hyprland'),
     dependency('pixman-1'),
     dependency('libdrm'),
-    dependency('pangocairo')
+    dependency('pangocairo'),
+    dependency('libinput'),
+    dependency('libudev'),
+    dependency('wayland-server'),
   ],
   install: true,
 )


### PR DESCRIPTION
Fixes issue #63 

Both hyprland and wlroots is listed under the flags because there is a possibility of both a bundled wlroots and a wlroots package as a dependency. Worst case scenario I guess is that there might sometimes be an extra unneeded dependency.  

Based on my observations, it seems the bundled wlroots is more common in distro packages but some people might still use the wlroots package of their distro and use that if they compile from source. This could possibly break some existing plugin packages like the hyprland plugins package that is currently in the aur due to the dependency of wlroots. Feel free to remove hyprland or wlroots from the flags if you feel it is necessary.