### PR TITLE
Nix: use mkHyprlandPlugin from nixpkgs

### DIFF
--- a/borders-plus-plus/default.nix
+++ b/borders-plus-plus/default.nix
@@ -1,16 +1,14 @@
 {
   lib,
-  stdenv,
   hyprland,
+  hyprlandPlugins,
 }:
-stdenv.mkDerivation {
-  pname = "borders-plus-plus";
+hyprlandPlugins.mkHyprlandPlugin {
+  pluginName = "borders-plus-plus";
   version = "0.1";
   src = ./.;
 
   inherit (hyprland) nativeBuildInputs;
-
-  buildInputs = [hyprland] ++ hyprland.buildInputs;
 
   meta = with lib; {
     homepage = "https://github.com/hyprwm/hyprland-plugins";

--- a/csgo-vulkan-fix/default.nix
+++ b/csgo-vulkan-fix/default.nix
@@ -1,16 +1,14 @@
 {
   lib,
-  stdenv,
   hyprland,
+  hyprlandPlugins,
 }:
-stdenv.mkDerivation {
-  pname = "csgo-vulkan-fix";
+hyprlandPlugins.mkHyprlandPlugin {
+  pluginName = "csgo-vulkan-fix";
   version = "0.1";
   src = ./.;
 
   inherit (hyprland) nativeBuildInputs;
-
-  buildInputs = [hyprland] ++ hyprland.buildInputs;
 
   meta = with lib; {
     homepage = "https://github.com/hyprwm/hyprland-plugins";

--- a/flake.lock
+++ b/flake.lock
@@ -3,17 +3,18 @@
     "hyprland": {
       "inputs": {
         "hyprland-protocols": "hyprland-protocols",
+        "hyprlang": "hyprlang",
         "nixpkgs": "nixpkgs",
         "systems": "systems",
         "wlroots": "wlroots",
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1706382674,
-        "narHash": "sha256-wuSs8Tm9GweeCEGIwamdMMZmOPF+8WWMM1YdH6jdA/w=",
+        "lastModified": 1709802223,
+        "narHash": "sha256-0tzkHwQ45ytvYjmqzjOi5TFnR0qaZRxOvzRZFhv7Oew=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "bc7e488a4c7a4bfdd7bce66265fe8aea516fd2ed",
+        "rev": "77161fdbef72033ea1989e4c4d386a5732bd6bf0",
         "type": "github"
       },
       "original": {
@@ -51,16 +52,19 @@
       "inputs": {
         "nixpkgs": [
           "hyprland",
-          "xdph",
           "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
         ]
       },
       "locked": {
-        "lastModified": 1704287638,
-        "narHash": "sha256-TuRXJGwtK440AXQNl5eiqmQqY4LZ/9+z/R7xC0ie3iA=",
+        "lastModified": 1709775675,
+        "narHash": "sha256-G+gIMUQBtfbbrnsM/OPJzebdqKFP6typplNCE7X8Szw=",
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "rev": "6624f2bb66d4d27975766e81f77174adbe58ec97",
+        "rev": "f1db1a7e1faee2a5c67d03b6bd283da82eed3730",
         "type": "github"
       },
       "original": {
@@ -71,11 +75,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1706191920,
-        "narHash": "sha256-eLihrZAPZX0R6RyM5fYAWeKVNuQPYjAkCUBr+JNvtdE=",
+        "lastModified": 1709703039,
+        "narHash": "sha256-6hqgQ8OK6gsMu1VtcGKBxKQInRLHtzulDo9Z5jxHEFY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ae5c332cbb5827f6b1f02572496b141021de335f",
+        "rev": "9df3e30ce24fd28c7b3e2de0d986769db5d6225d",
         "type": "github"
       },
       "original": {
@@ -87,7 +91,11 @@
     },
     "root": {
       "inputs": {
-        "hyprland": "hyprland"
+        "hyprland": "hyprland",
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
       }
     },
     "systems": {
@@ -109,18 +117,18 @@
       "flake": false,
       "locked": {
         "host": "gitlab.freedesktop.org",
-        "lastModified": 1706359063,
-        "narHash": "sha256-5HUTG0p+nCJv3cn73AmFHRZdfRV5AD5N43g8xAePSKM=",
+        "lastModified": 1708558866,
+        "narHash": "sha256-Mz6hCtommq7RQfcPnxLINigO4RYSNt23HeJHC6mVmWI=",
         "owner": "wlroots",
         "repo": "wlroots",
-        "rev": "00b869c1a96f300a8f25da95d624524895e0ddf2",
+        "rev": "0cb091f1a2d345f37d2ee445f4ffd04f7f4ec9e5",
         "type": "gitlab"
       },
       "original": {
         "host": "gitlab.freedesktop.org",
         "owner": "wlroots",
         "repo": "wlroots",
-        "rev": "00b869c1a96f300a8f25da95d624524895e0ddf2",
+        "rev": "0cb091f1a2d345f37d2ee445f4ffd04f7f4ec9e5",
         "type": "gitlab"
       }
     },
@@ -130,7 +138,10 @@
           "hyprland",
           "hyprland-protocols"
         ],
-        "hyprlang": "hyprlang",
+        "hyprlang": [
+          "hyprland",
+          "hyprlang"
+        ],
         "nixpkgs": [
           "hyprland",
           "nixpkgs"
@@ -141,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706145785,
-        "narHash": "sha256-j9MP4fv2U/vdRKAXXc2gyMTmYwVnHP6kHx1/y6jprrU=",
+        "lastModified": 1709299639,
+        "narHash": "sha256-jYqJM5khksLIbqSxCLUUcqEgI+O2LdlSlcMEBs39CAU=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "5a592647587cd20b9692a347df6939b6d371b3bb",
+        "rev": "2d2fb547178ec025da643db57d40a971507b82fe",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,36 +1,66 @@
 {
   description = "Hyprland Plugins";
 
-  inputs.hyprland.url = "github:hyprwm/Hyprland";
+  inputs = {
+    hyprland.url = "github:hyprwm/Hyprland";
+    systems.follows = "hyprland/systems";
+  };
 
-  outputs = inputs: let
-    inherit (inputs.hyprland.inputs) nixpkgs;
-    withPkgsFor = fn: nixpkgs.lib.genAttrs (builtins.attrNames inputs.hyprland.packages) (system: fn system nixpkgs.legacyPackages.${system});
+  outputs = {
+    self,
+    hyprland,
+    systems,
+    ...
+  }: let
+    inherit (hyprland.inputs) nixpkgs;
+    inherit (nixpkgs) lib;
+    eachSystem = lib.genAttrs (import systems);
+
+    pkgsFor = eachSystem (system:
+      import nixpkgs {
+        localSystem.system = system;
+        overlays = with self.overlays; [hyprland-plugins];
+      });
   in {
-    packages = withPkgsFor (system: pkgs: let
-      hyprland = inputs.hyprland.packages.${system}.hyprland;
-      buildPlugin = path: extraArgs:
-        pkgs.callPackage path {
-          inherit hyprland;
-          inherit (hyprland) stdenv;
-        }
-        // extraArgs;
-    in {
-      borders-plus-plus = buildPlugin ./borders-plus-plus {};
-      csgo-vulkan-fix = buildPlugin ./csgo-vulkan-fix {};
-      hyprbars = buildPlugin ./hyprbars {};
-      hyprtrails = buildPlugin ./hyprtrails {};
-      hyprwinwrap = buildPlugin ./hyprwinwrap {};
+    packages = eachSystem (system: {
+      inherit (pkgsFor.${system}) borders-plus-plus csgo-vulkan-fix hyprbars hyprtrails hyprwinwrap;
     });
 
-    checks = withPkgsFor (system: pkgs: inputs.self.packages.${system});
+    overlays = {
+      default = self.overlays.hyprland-plugins;
+      mkHyprlandPlugin = lib.composeManyExtensions [
+        hyprland.overlays.default
+        (final: prev: {
+          hyprlandPlugins =
+            prev.hyprlandPlugins
+            // {
+              mkHyprlandPlugin = prev.hyprlandPlugins.mkHyprlandPlugin final.hyprland;
+            };
+        })
+      ];
+      hyprland-plugins = lib.composeManyExtensions [
+        self.overlays.mkHyprlandPlugin
+        (final: prev: let
+          inherit (final) callPackage;
+        in {
+          borders-plus-plus = callPackage ./borders-plus-plus {};
+          csgo-vulkan-fix = callPackage ./csgo-vulkan-fix {};
+          hyprbars = callPackage ./hyprbars {};
+          hyprtrails = callPackage ./hyprtrails {};
+          hyprwinwrap = callPackage ./hyprwinwrap {};
+        })
+      ];
+    };
 
-    devShells = withPkgsFor (system: pkgs: {
-      default = pkgs.mkShell.override {stdenv = pkgs.gcc13Stdenv;} {
-        name = "hyprland-plugins";
-        buildInputs = [inputs.hyprland.packages.${system}.hyprland];
-        inputsFrom = [inputs.hyprland.packages.${system}.hyprland];
-      };
-    });
+    checks = eachSystem (system: self.packages.${system});
+
+    devShells = eachSystem (system:
+      with pkgsFor.${system}; {
+        default = mkShell.override {stdenv = gcc13Stdenv;} {
+          name = "hyprland-plugins";
+          buildInputs = [hyprland.packages.${system}.hyprland];
+          inputsFrom = [hyprland.packages.${system}.hyprland];
+        };
+      });
   };
 }

--- a/hyprbars/default.nix
+++ b/hyprbars/default.nix
@@ -1,16 +1,14 @@
 {
   lib,
-  stdenv,
   hyprland,
+  hyprlandPlugins,
 }:
-stdenv.mkDerivation {
-  pname = "hyprbars";
+hyprlandPlugins.mkHyprlandPlugin {
+  pluginName = "hyprbars";
   version = "0.1";
   src = ./.;
 
   inherit (hyprland) nativeBuildInputs;
-
-  buildInputs = [hyprland] ++ hyprland.buildInputs;
 
   meta = with lib; {
     homepage = "https://github.com/hyprwm/hyprland-plugins";

--- a/hyprtrails/default.nix
+++ b/hyprtrails/default.nix
@@ -1,16 +1,14 @@
 {
   lib,
-  stdenv,
   hyprland,
+  hyprlandPlugins,
 }:
-stdenv.mkDerivation {
-  pname = "hyprtrails";
+hyprlandPlugins.mkHyprlandPlugin {
+  pluginName = "hyprtrails";
   version = "0.1";
   src = ./.;
 
   inherit (hyprland) nativeBuildInputs;
-
-  buildInputs = [hyprland] ++ hyprland.buildInputs;
 
   meta = with lib; {
     homepage = "https://github.com/hyprwm/hyprland-plugins";

--- a/hyprwinwrap/default.nix
+++ b/hyprwinwrap/default.nix
@@ -1,16 +1,14 @@
 {
   lib,
-  stdenv,
   hyprland,
+  hyprlandPlugins,
 }:
-stdenv.mkDerivation {
-  pname = "hyprwinwrap";
+hyprlandPlugins.mkHyprlandPlugin {
+  pluginName = "hyprwinwrap";
   version = "0.1";
   src = ./.;
 
   inherit (hyprland) nativeBuildInputs;
-
-  buildInputs = [hyprland] ++ hyprland.buildInputs;
 
   meta = with lib; {
     homepage = "https://github.com/hyprwm/hyprland-plugins";


### PR DESCRIPTION
This PR unifies the build mechanism in hyprland-plugins with the one in Nixpkgs.
This provides help for plugin developers wishing to write a derivation for their
plugin and checking this repo for examples.

The plugins build, but I haven't tested them. If you can, please do test them.
