### PR TITLE
Fix hyprbars for hyprland 0.37.1

### DIFF
--- a/hyprbars/barDeco.cpp
+++ b/hyprbars/barDeco.cpp
@@ -1,7 +1,7 @@
 #include "barDeco.hpp"
 
 #include <hyprland/src/Compositor.hpp>
-#include <hyprland/src/desktop/Window.hpp>
+#include <hyprland/src/Window.hpp>
 #include <pango/pangocairo.h>
 
 #include "globals.hpp"

--- a/hyprbars/main.cpp
+++ b/hyprbars/main.cpp
@@ -4,7 +4,7 @@
 
 #include <any>
 #include <hyprland/src/Compositor.hpp>
-#include <hyprland/src/desktop/Window.hpp>
+#include <hyprland/src/Window.hpp>
 #include <hyprland/src/config/ConfigManager.hpp>
 
 #include "barDeco.hpp"


### PR DESCRIPTION
Window.hpp was moved from src/desktop/Window.hpp to src/Window.hpp

p.s. i hate github's website :sob: