### PR TITLE
treewide: add CMake files

### DIFF
--- a/borders-plus-plus/CMakeLists.txt
+++ b/borders-plus-plus/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.27)
+
+project(borders-plus-plus
+    DESCRIPTION "borders-plus-plus plugin for Hyprland"
+    VERSION 0.1
+)
+
+set(CMAKE_CXX_STANDARD 23)
+
+file(GLOB_RECURSE SRC "*.cpp")
+
+add_library(borders-plus-plus SHARED ${SRC})
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(deps REQUIRED IMPORTED_TARGET
+    hyprland
+    libdrm
+    libinput
+    libudev
+    pangocairo
+    pixman-1
+    wayland-server
+    xkbcommon
+)
+target_link_libraries(borders-plus-plus PRIVATE rt PkgConfig::deps)
+
+install(TARGETS borders-plus-plus)

--- a/borders-plus-plus/default.nix
+++ b/borders-plus-plus/default.nix
@@ -3,7 +3,7 @@
   hyprland,
   hyprlandPlugins,
 }:
-hyprlandPlugins.mkHyprlandPlugin {
+hyprlandPlugins.mkHyprlandPlugin hyprland {
   pluginName = "borders-plus-plus";
   version = "0.1";
   src = ./.;

--- a/csgo-vulkan-fix/CMakeLists.txt
+++ b/csgo-vulkan-fix/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.27)
+
+project(csgo-vulkan-fix
+    DESCRIPTION "csgo-vulkan-fix plugin for Hyprland"
+    VERSION 0.1
+)
+
+set(CMAKE_CXX_STANDARD 23)
+
+file(GLOB_RECURSE SRC "*.cpp")
+
+add_library(csgo-vulkan-fix SHARED ${SRC})
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(deps REQUIRED IMPORTED_TARGET
+    hyprland
+    libdrm
+    libinput
+    libudev
+    pangocairo
+    pixman-1
+    wayland-server
+    xkbcommon
+)
+target_link_libraries(csgo-vulkan-fix PRIVATE rt PkgConfig::deps)
+
+install(TARGETS csgo-vulkan-fix)

--- a/csgo-vulkan-fix/default.nix
+++ b/csgo-vulkan-fix/default.nix
@@ -3,7 +3,7 @@
   hyprland,
   hyprlandPlugins,
 }:
-hyprlandPlugins.mkHyprlandPlugin {
+hyprlandPlugins.mkHyprlandPlugin hyprland {
   pluginName = "csgo-vulkan-fix";
   version = "0.1";
   src = ./.;

--- a/flake.lock
+++ b/flake.lock
@@ -1,30 +1,11 @@
 {
   "nodes": {
-    "hyprland": {
+    "hyprcursor": {
       "inputs": {
-        "hyprland-protocols": "hyprland-protocols",
-        "hyprlang": "hyprlang",
-        "nixpkgs": "nixpkgs",
-        "systems": "systems",
-        "wlroots": "wlroots",
-        "xdph": "xdph"
-      },
-      "locked": {
-        "lastModified": 1709802223,
-        "narHash": "sha256-0tzkHwQ45ytvYjmqzjOi5TFnR0qaZRxOvzRZFhv7Oew=",
-        "owner": "hyprwm",
-        "repo": "Hyprland",
-        "rev": "77161fdbef72033ea1989e4c4d386a5732bd6bf0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "Hyprland",
-        "type": "github"
-      }
-    },
-    "hyprland-protocols": {
-      "inputs": {
+        "hyprlang": [
+          "hyprland",
+          "hyprlang"
+        ],
         "nixpkgs": [
           "hyprland",
           "nixpkgs"
@@ -35,11 +16,63 @@
         ]
       },
       "locked": {
-        "lastModified": 1691753796,
-        "narHash": "sha256-zOEwiWoXk3j3+EoF3ySUJmberFewWlagvewDRuWYAso=",
+        "lastModified": 1713612213,
+        "narHash": "sha256-zJboXgWNpNhKyNF8H/3UYzWkx7w00TOCGKi3cwi+tsw=",
+        "owner": "hyprwm",
+        "repo": "hyprcursor",
+        "rev": "cab4746180f210a3c1dd3d53e45c510e309e90e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprcursor",
+        "type": "github"
+      }
+    },
+    "hyprland": {
+      "inputs": {
+        "hyprcursor": "hyprcursor",
+        "hyprlang": "hyprlang",
+        "hyprwayland-scanner": "hyprwayland-scanner",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems",
+        "xdph": "xdph"
+      },
+      "locked": {
+        "lastModified": 1714915839,
+        "narHash": "sha256-HwrMGeMtYD2AXanipPSSzmc8IGZQsFVDotScXYztHNg=",
+        "ref": "refs/heads/main",
+        "rev": "589f758d947cb4e8b888d2da00076a9fb0a6d521",
+        "revCount": 4614,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/hyprwm/Hyprland"
+      },
+      "original": {
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/hyprwm/Hyprland"
+      }
+    },
+    "hyprland-protocols": {
+      "inputs": {
+        "nixpkgs": [
+          "hyprland",
+          "xdph",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "xdph",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1714869498,
+        "narHash": "sha256-vbLVOWvQqo4n1yvkg/Q70VTlPbMmTiCQfNTgcWDCfJM=",
         "owner": "hyprwm",
         "repo": "hyprland-protocols",
-        "rev": "0c2ce70625cb30aef199cb388f99e19a61a6ce03",
+        "rev": "e06482e0e611130cd1929f75e8c1cf679e57d161",
         "type": "github"
       },
       "original": {
@@ -60,11 +93,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709775675,
-        "narHash": "sha256-G+gIMUQBtfbbrnsM/OPJzebdqKFP6typplNCE7X8Szw=",
+        "lastModified": 1713121246,
+        "narHash": "sha256-502X0Q0fhN6tJK7iEUA8CghONKSatW/Mqj4Wappd++0=",
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "rev": "f1db1a7e1faee2a5c67d03b6bd283da82eed3730",
+        "rev": "78fcaa27ae9e1d782faa3ff06c8ea55ddce63706",
         "type": "github"
       },
       "original": {
@@ -73,13 +106,38 @@
         "type": "github"
       }
     },
+    "hyprwayland-scanner": {
+      "inputs": {
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1714755542,
+        "narHash": "sha256-D0pg+ZRwrt4lavZ97Ca8clsgbPA3duLj8iEM7riaIFY=",
+        "owner": "hyprwm",
+        "repo": "hyprwayland-scanner",
+        "rev": "1270ebaa539e56d61b708c24b072b09cbbd3a828",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprwayland-scanner",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1709703039,
-        "narHash": "sha256-6hqgQ8OK6gsMu1VtcGKBxKQInRLHtzulDo9Z5jxHEFY=",
+        "lastModified": 1714253743,
+        "narHash": "sha256-mdTQw2XlariysyScCv2tTE45QSU9v/ezLcHJ22f0Nxc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9df3e30ce24fd28c7b3e2de0d986769db5d6225d",
+        "rev": "58a1abdbae3217ca6b702f03d3b35125d88a2994",
         "type": "github"
       },
       "original": {
@@ -113,31 +171,9 @@
         "type": "github"
       }
     },
-    "wlroots": {
-      "flake": false,
-      "locked": {
-        "host": "gitlab.freedesktop.org",
-        "lastModified": 1708558866,
-        "narHash": "sha256-Mz6hCtommq7RQfcPnxLINigO4RYSNt23HeJHC6mVmWI=",
-        "owner": "wlroots",
-        "repo": "wlroots",
-        "rev": "0cb091f1a2d345f37d2ee445f4ffd04f7f4ec9e5",
-        "type": "gitlab"
-      },
-      "original": {
-        "host": "gitlab.freedesktop.org",
-        "owner": "wlroots",
-        "repo": "wlroots",
-        "rev": "0cb091f1a2d345f37d2ee445f4ffd04f7f4ec9e5",
-        "type": "gitlab"
-      }
-    },
     "xdph": {
       "inputs": {
-        "hyprland-protocols": [
-          "hyprland",
-          "hyprland-protocols"
-        ],
+        "hyprland-protocols": "hyprland-protocols",
         "hyprlang": [
           "hyprland",
           "hyprlang"
@@ -152,11 +188,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709299639,
-        "narHash": "sha256-jYqJM5khksLIbqSxCLUUcqEgI+O2LdlSlcMEBs39CAU=",
+        "lastModified": 1714060055,
+        "narHash": "sha256-j43TS9wv9luaAlpxcxw0sjxkbcc2mGANVR2RYgo3RCw=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "2d2fb547178ec025da643db57d40a971507b82fe",
+        "rev": "0fe840441e43da12cd7865ed9aa8cdc35a8da85a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Hyprland Plugins";
 
   inputs = {
-    hyprland.url = "github:hyprwm/Hyprland";
+    hyprland.url = "git+https://github.com/hyprwm/Hyprland?submodules=1";
     systems.follows = "hyprland/systems";
   };
 
@@ -19,38 +19,37 @@
     pkgsFor = eachSystem (system:
       import nixpkgs {
         localSystem.system = system;
-        overlays = with self.overlays; [hyprland-plugins];
+        overlays = [
+          self.overlays.hyprland-plugins
+          hyprland.overlays.hyprland-packages
+        ];
       });
   in {
     packages = eachSystem (system: {
-      inherit (pkgsFor.${system}) borders-plus-plus csgo-vulkan-fix hyprbars hyprexpo hyprtrails hyprwinwrap;
+      inherit
+        (pkgsFor.${system})
+        borders-plus-plus
+        csgo-vulkan-fix
+        hyprbars
+        hyprexpo
+        hyprtrails
+        hyprwinwrap
+        ;
     });
 
     overlays = {
       default = self.overlays.hyprland-plugins;
-      mkHyprlandPlugin = lib.composeManyExtensions [
-        hyprland.overlays.default
-        (final: prev: {
-          hyprlandPlugins =
-            prev.hyprlandPlugins
-            // {
-              mkHyprlandPlugin = prev.hyprlandPlugins.mkHyprlandPlugin final.hyprland;
-            };
-        })
-      ];
-      hyprland-plugins = lib.composeManyExtensions [
-        self.overlays.mkHyprlandPlugin
-        (final: prev: let
-          inherit (final) callPackage;
-        in {
-          borders-plus-plus = callPackage ./borders-plus-plus {};
-          csgo-vulkan-fix = callPackage ./csgo-vulkan-fix {};
-          hyprbars = callPackage ./hyprbars {};
-          hyprexpo = callPackage ./hyprexpo {};
-          hyprtrails = callPackage ./hyprtrails {};
-          hyprwinwrap = callPackage ./hyprwinwrap {};
-        })
-      ];
+
+      hyprland-plugins = final: prev: let
+        inherit (final) callPackage;
+      in {
+        borders-plus-plus = callPackage ./borders-plus-plus {};
+        csgo-vulkan-fix = callPackage ./csgo-vulkan-fix {};
+        hyprbars = callPackage ./hyprbars {};
+        hyprexpo = callPackage ./hyprexpo {};
+        hyprtrails = callPackage ./hyprtrails {};
+        hyprwinwrap = callPackage ./hyprwinwrap {};
+      };
     };
 
     checks = eachSystem (system: self.packages.${system});

--- a/hyprbars/CMakeLists.txt
+++ b/hyprbars/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.27)
+
+project(hyprbars
+    DESCRIPTION "hyprbars plugin for Hyprland"
+    VERSION 0.1
+)
+
+set(CMAKE_CXX_STANDARD 23)
+
+file(GLOB_RECURSE SRC "*.cpp")
+
+add_library(hyprbars SHARED ${SRC})
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(deps REQUIRED IMPORTED_TARGET
+    hyprland
+    libdrm
+    libinput
+    libudev
+    pangocairo
+    pixman-1
+    wayland-server
+    xkbcommon
+)
+target_link_libraries(hyprbars PRIVATE rt PkgConfig::deps)
+
+install(TARGETS hyprbars)

--- a/hyprbars/default.nix
+++ b/hyprbars/default.nix
@@ -3,7 +3,7 @@
   hyprland,
   hyprlandPlugins,
 }:
-hyprlandPlugins.mkHyprlandPlugin {
+hyprlandPlugins.mkHyprlandPlugin hyprland {
   pluginName = "hyprbars";
   version = "0.1";
   src = ./.;

--- a/hyprexpo/CMakeLists.txt
+++ b/hyprexpo/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.27)
+
+project(hyprexpo
+    DESCRIPTION "hyprexpo plugin for Hyprland"
+    VERSION 0.1
+)
+
+set(CMAKE_CXX_STANDARD 23)
+
+file(GLOB_RECURSE SRC "*.cpp")
+
+add_library(hyprexpo SHARED ${SRC})
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(deps REQUIRED IMPORTED_TARGET
+    hyprland
+    libdrm
+    libinput
+    libudev
+    pangocairo
+    pixman-1
+    wayland-server
+    xkbcommon
+)
+target_link_libraries(hyprexpo PRIVATE rt PkgConfig::deps)
+
+install(TARGETS hyprexpo)

--- a/hyprexpo/default.nix
+++ b/hyprexpo/default.nix
@@ -3,7 +3,7 @@
   hyprland,
   hyprlandPlugins,
 }:
-hyprlandPlugins.mkHyprlandPlugin {
+hyprlandPlugins.mkHyprlandPlugin hyprland {
   pluginName = "hyprexpo";
   version = "0.1";
   src = ./.;

--- a/hyprtrails/CMakeLists.txt
+++ b/hyprtrails/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.27)
+
+project(hyprtrails
+    DESCRIPTION "hyprtrails plugin for Hyprland"
+    VERSION 0.1
+)
+
+set(CMAKE_CXX_STANDARD 23)
+
+file(GLOB_RECURSE SRC "*.cpp")
+
+add_library(hyprtrails SHARED ${SRC})
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(deps REQUIRED IMPORTED_TARGET
+    hyprland
+    libdrm
+    libinput
+    libudev
+    pangocairo
+    pixman-1
+    wayland-server
+    xkbcommon
+)
+target_link_libraries(hyprtrails PRIVATE rt PkgConfig::deps)
+
+install(TARGETS hyprtrails)

--- a/hyprtrails/default.nix
+++ b/hyprtrails/default.nix
@@ -3,7 +3,7 @@
   hyprland,
   hyprlandPlugins,
 }:
-hyprlandPlugins.mkHyprlandPlugin {
+hyprlandPlugins.mkHyprlandPlugin hyprland {
   pluginName = "hyprtrails";
   version = "0.1";
   src = ./.;

--- a/hyprwinwrap/CMakeLists.txt
+++ b/hyprwinwrap/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.27)
+
+project(hyprwinwrap
+    DESCRIPTION "hyprwinwrap plugin for Hyprland"
+    VERSION 0.1
+)
+
+set(CMAKE_CXX_STANDARD 23)
+
+file(GLOB_RECURSE SRC "*.cpp")
+
+add_library(hyprwinwrap SHARED ${SRC})
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(deps REQUIRED IMPORTED_TARGET
+    hyprland
+    libdrm
+    libinput
+    libudev
+    pangocairo
+    pixman-1
+    wayland-server
+    xkbcommon
+)
+target_link_libraries(hyprwinwrap PRIVATE rt PkgConfig::deps)
+
+install(TARGETS hyprwinwrap)

--- a/hyprwinwrap/default.nix
+++ b/hyprwinwrap/default.nix
@@ -3,7 +3,7 @@
   hyprland,
   hyprlandPlugins,
 }:
-hyprlandPlugins.mkHyprlandPlugin {
+hyprlandPlugins.mkHyprlandPlugin hyprland {
   pluginName = "hyprwinwrap";
   version = "0.1";
   src = ./.;


### PR DESCRIPTION
Complements hyprwm/Hyprland#5667

Switch Nix builds to use CMake instead of Meson. Meson might be deprecated in
the future.

Simplify overlay mechanism. Overlaying `hyprland.overlays.hyprland-packages` on
top of Nixpkgs works perfectly, whereas providing the flake package to the
`mkHyprlandPlugin` function does not. I might remove that feature in the future.

Feel free to test and report any issues.
