### PR TITLE
expo: add option for gesture fingers

### DIFF
--- a/hyprexpo/README.md
+++ b/hyprexpo/README.md
@@ -15,7 +15,8 @@ plugin {
         bg_col = rgb(111111)
         workspace_method = center current # [center/first] [workspace] e.g. first 1 or center m+1
 
-        enable_gesture = true # laptop touchpad, 4 fingers
+        enable_gesture = true # laptop touchpad
+        gesture_fingers = 3  # 3 or 4
         gesture_distance = 300 # how far is the "max"
         gesture_positive = true # positive = swipe down. Negative = swipe up.
     }

--- a/hyprexpo/main.cpp
+++ b/hyprexpo/main.cpp
@@ -108,6 +108,7 @@ static void swipeEnd(void* self, SCallbackInfo& info, std::any param) {
     if (!g_pOverview)
         return;
 
+    swipeActive = false;
     info.cancelled = true;
 
     g_pOverview->onSwipeEnd();
@@ -115,6 +116,8 @@ static void swipeEnd(void* self, SCallbackInfo& info, std::any param) {
 
 static void onExpoDispatcher(std::string arg) {
 
+    if (swipeActive)
+        return;
     if (arg == "toggle") {
         if (g_pOverview)
             g_pOverview->close();

--- a/hyprexpo/main.cpp
+++ b/hyprexpo/main.cpp
@@ -14,15 +14,9 @@
 inline CFunctionHook* g_pRenderWorkspaceHook = nullptr;
 inline CFunctionHook* g_pAddDamageHookA      = nullptr;
 inline CFunctionHook* g_pAddDamageHookB      = nullptr;
-inline CFunctionHook* g_pSwipeBeginHook      = nullptr;
-inline CFunctionHook* g_pSwipeEndHook        = nullptr;
-inline CFunctionHook* g_pSwipeUpdateHook     = nullptr;
 typedef void          (*origRenderWorkspace)(void*, CMonitor*, PHLWORKSPACE, timespec*, const CBox&);
 typedef void          (*origAddDamageA)(void*, const CBox*);
 typedef void          (*origAddDamageB)(void*, const pixman_region32_t*);
-typedef void          (*origSwipeBegin)(void*, wlr_pointer_swipe_begin_event*);
-typedef void          (*origSwipeEnd)(void*, wlr_pointer_swipe_end_event*);
-typedef void          (*origSwipeUpdate)(void*, wlr_pointer_swipe_update_event*);
 
 // Do NOT change this function.
 APICALL EXPORT std::string PLUGIN_API_VERSION() {

--- a/hyprexpo/main.cpp
+++ b/hyprexpo/main.cpp
@@ -99,7 +99,8 @@ static void swipeUpdate(void* self, SCallbackInfo& info, std::any param) {
     }
 
     gestured += (**PPOSITIVE ? 1.0 : -1.0) * e.delta.y;
-
+    if (gestured <= 0.01) // plugin will crash if swipe ends at <= 0
+        gestured = 0.01;
     g_pOverview->onSwipeUpdate(gestured);
 }
 

--- a/hyprexpo/overview.cpp
+++ b/hyprexpo/overview.cpp
@@ -439,6 +439,13 @@ void COverview::onSwipeUpdate(double delta) {
 }
 
 void COverview::onSwipeEnd() {
+    const auto SIZEMIN = pMonitor->vecSize;
+    const auto SIZEMAX = pMonitor->vecSize * pMonitor->vecSize / (pMonitor->vecSize / SIDE_LENGTH);
+    const auto PERC    = (size.value() - SIZEMIN).x / (SIZEMAX - SIZEMIN).x;
+    if (PERC > 0.5) {
+        close();
+        return;
+    }
     size = pMonitor->vecSize;
     pos  = {0, 0};
 


### PR DESCRIPTION
I added a config value for gesture fingers and improved gesture detection by adding some checks so it doesn't get triggered when swiping horizontally or in the opposite direction of gesture_positive, this makes the gesture compatible with workspace swipe to use both gestures with the same number of fingers