### PR TITLE
hyprbars: add bar_color & title_color windowrules

### DIFF
--- a/hyprbars/README.md
+++ b/hyprbars/README.md
@@ -59,3 +59,5 @@ hyprbars-button = color, size, icon, on-click
 Hyprbars supports the following _dynamic_ window rules:
 
 `plugin:hyprbars:nobar` -> disables the bar on matching windows.
+`plugin:hyprbars:bar_color` -> sets the bar background color on matching windows.
+`plugin:hyprbars:title_color` -> sets the bar title color on matching windows.

--- a/hyprbars/barDeco.hpp
+++ b/hyprbars/barDeco.hpp
@@ -34,39 +34,43 @@ class CHyprBar : public IHyprWindowDecoration {
 
     PHLWINDOW                          getOwner();
 
-    void                               setHidden(bool hidden);
+    void                               updateRules();
+    void                               applyRule(const SWindowRule&);
 
   private:
-    SBoxExtents          m_seExtents;
+    SBoxExtents           m_seExtents;
 
-    PHLWINDOWREF         m_pWindow;
+    PHLWINDOWREF          m_pWindow;
 
-    CBox                 m_bAssignedBox;
+    CBox                  m_bAssignedBox;
 
-    SP<CTexture>         m_pTextTex;
-    SP<CTexture>         m_pButtonsTex;
+    SP<CTexture>          m_pTextTex;
+    SP<CTexture>          m_pButtonsTex;
 
-    bool                 m_bWindowSizeChanged = false;
-    bool                 m_bHidden            = false;
+    bool                  m_bWindowSizeChanged = false;
+    bool                  m_bHidden            = false;
+    bool                  m_bTitleColorChanged = false;
+    std::optional<CColor> m_bForcedBarColor;
+    std::optional<CColor> m_bForcedTitleColor;
 
-    Vector2D             cursorRelativeToBar();
+    Vector2D              cursorRelativeToBar();
 
-    void                 renderBarTitle(const Vector2D& bufferSize, const float scale);
-    void                 renderText(SP<CTexture> out, const std::string& text, const CColor& color, const Vector2D& bufferSize, const float scale, const int fontSize);
-    void                 renderBarButtons(const Vector2D& bufferSize, const float scale);
-    void                 renderBarButtonsText(CBox* barBox, const float scale, const float a);
-    void                 onMouseDown(SCallbackInfo& info, IPointer::SButtonEvent e);
-    void                 onMouseMove(Vector2D coords);
-    CBox                 assignedBoxGlobal();
+    void                  renderBarTitle(const Vector2D& bufferSize, const float scale);
+    void                  renderText(SP<CTexture> out, const std::string& text, const CColor& color, const Vector2D& bufferSize, const float scale, const int fontSize);
+    void                  renderBarButtons(const Vector2D& bufferSize, const float scale);
+    void                  renderBarButtonsText(CBox* barBox, const float scale, const float a);
+    void                  onMouseDown(SCallbackInfo& info, IPointer::SButtonEvent e);
+    void                  onMouseMove(Vector2D coords);
+    CBox                  assignedBoxGlobal();
 
-    SP<HOOK_CALLBACK_FN> m_pMouseButtonCallback;
-    SP<HOOK_CALLBACK_FN> m_pMouseMoveCallback;
+    SP<HOOK_CALLBACK_FN>  m_pMouseButtonCallback;
+    SP<HOOK_CALLBACK_FN>  m_pMouseMoveCallback;
 
-    std::string          m_szLastTitle;
+    std::string           m_szLastTitle;
 
-    bool                 m_bDraggingThis  = false;
-    bool                 m_bDragPending   = false;
-    bool                 m_bCancelledDown = false;
+    bool                  m_bDraggingThis  = false;
+    bool                  m_bDragPending   = false;
+    bool                  m_bCancelledDown = false;
 
     // for dynamic updates
     int m_iLastHeight = 0;

--- a/hyprbars/main.cpp
+++ b/hyprbars/main.cpp
@@ -49,9 +49,8 @@ static void onUpdateWindowRules(PHLWINDOW window) {
     if (BARIT == g_pGlobalState->bars.end())
         return;
 
-    const auto HASNOBAR = std::find_if(window->m_vMatchedRules.begin(), window->m_vMatchedRules.end(), [](const auto& rule) { return rule.szRule == "plugin:hyprbars:nobar"; }) != window->m_vMatchedRules.end();
-
-    (*BARIT)->setHidden(HASNOBAR);
+    (*BARIT)->updateRules();
+    window->updateWindowDecos();
 }
 
 Hyprlang::CParseResult onNewButton(const char* K, const char* V) {


### PR DESCRIPTION
Fixes https://github.com/hyprwm/hyprland-plugins/issues/72

Adds two windowrules, for setting bg and fg color.

Some cool use cases:
- When interacting with remote hosts (e.g. SSH, [waypipe](https://gitlab.freedesktop.org/mstoeckl/waypipe)), make the bar match the host's colorscheme (my personal one)
- Make `sudo` tint the bar red (like gnome's)
- Get a different color when visiting your favorite site
- Tint focused windows (#72)

https://github.com/hyprwm/hyprland-plugins/assets/5727578/180da41f-3955-4091-ab3a-579a337dabf0

<details>

```
windowrulev2=plugin:hyprbars:bar_color 0xdd1e1010, title:^\[pleione\]
windowrulev2=plugin:hyprbars:title_color 0xeef8dcdc, title:^\[pleione\]
windowrulev2=bordercolor 0xaaf6adfe 0xaa473535, title:^\[pleione\]

windowrulev2=plugin:hyprbars:bar_color 0xdde36f6f, title:sudo
windowrulev2=plugin:hyprbars:title_color 0xeeeeeeee, title:sudo
windowrulev2=plugin:hyprbars:bar_color 0xdde36f6f, title:root@
windowrulev2=plugin:hyprbars:title_color 0xeeeeeeee, title:root@

windowrulev2=plugin:hyprbars:bar_color 0xee651b96, title:Gabriel Fontes
windowrulev2=plugin:hyprbars:title_color 0xeeeeeeee, title:Gabriel Fontes
```

</details>

I tried my best to make it consistent with surrounding code. I've refactored `nobar` so that hyprbars windowrules are applied similarly to [hyprland](https://github.com/hyprwm/Hyprland/blob/main/src/desktop/Window.cpp#L607)'s (i.e. with a dedicated `applyRule(SWindowRule)` function). Please let me know if there's anything that can be improved!