### PR TITLE
csgo-vulkan-fix: change cs2 class to match current class

### DIFF
--- a/csgo-vulkan-fix/README.md
+++ b/csgo-vulkan-fix/README.md
@@ -12,7 +12,7 @@ With this plugin, you aren't anymore.
 
 CS2 launch options:
 ```
--vulkan -window -w <RESX> -h <RESY> -vulkan
+-window -w <RESX> -h <RESY>
 ```
 
 example plugin config:
@@ -23,7 +23,8 @@ plugin {
         res_h = 1050
 
         # NOT a regex! This is a string and has to exactly match initial_class
-        class = cs2
+        # At some point Counter Strike 2's class was changed to 'SDL Application'
+        class = SDL Application
 
         # Whether to fix the mouse position. A select few apps might be wonky with this.
         fix_mouse = true


### PR DESCRIPTION
At some point CS2 changed the class name to 'SDL Application'. The plugin no longer targets the game with it set to cs2.

Also removed the unnecessary -vulkan options as is isn't valid anymore.