### PR TITLE
make borders++ sticky, fix scaling issues

### DIFF
--- a/borders-plus-plus/borderDeco.hpp
+++ b/borders-plus-plus/borderDeco.hpp
@@ -33,6 +33,7 @@ class CBordersPlusPlus : public IHyprWindowDecoration {
     PHLWINDOWREF m_pWindow;
 
     CBox         m_bLastRelativeBox;
+    CBox         m_bAssignedGeometry;
 
     Vector2D     m_vLastWindowPos;
     Vector2D     m_vLastWindowSize;


### PR DESCRIPTION
fixed an issue where borders++ was not adhering to higher-priority sticky decorations (like hyprbars with border_precedence turned on) due to borders++ following the ABSOLUTE policy rather than STICKY. this addresses issue #215 

before (natural rounding off, 2 border++s, with hyprbars)
![screenshot_2024-09-28-151449](https://github.com/user-attachments/assets/6ca666ba-bb32-41d2-a10d-2147cad84d16)


after
![screenshot_2024-09-28-150957](https://github.com/user-attachments/assets/76fe2405-d3a0-4491-86c3-590caaf4bf78)

if u look closely, now there is no gaps between borders :+1: :smiley: 

there is still a gap between the shadows and borders, i think the only way to fix this is by making rounding be affected by sticky decos somehow, and then assigning it to the drop shadow. correct me if im wrong

edit: i meant borders++ oops