### PR TITLE
Fix 60c5c63

### DIFF
--- a/borders-plus-plus/borderDeco.cpp
+++ b/borders-plus-plus/borderDeco.cpp
@@ -59,7 +59,7 @@ std::string CBordersPlusPlus::getDisplayName() {
     return "Borders++";
 }
 
-void CBordersPlusPlus::draw(PHLMONITOR pMonitor, float a) {
+void CBordersPlusPlus::draw(PHLMONITOR pMonitor, const float &a) {
     if (!validMapped(m_pWindow))
         return;
 

--- a/hyprbars/barDeco.cpp
+++ b/hyprbars/barDeco.cpp
@@ -383,7 +383,7 @@ void CHyprBar::renderBarButtonsText(CBox* barBox, const float scale, const float
     }
 }
 
-void CHyprBar::draw(PHLMONITOR pMonitor, float a) {
+void CHyprBar::draw(PHLMONITOR pMonitor, const float &a) {
     if (m_bHidden || !validMapped(m_pWindow))
         return;
 

--- a/hyprexpo/overview.cpp
+++ b/hyprexpo/overview.cpp
@@ -237,8 +237,8 @@ void COverview::redrawID(int id, bool forcelowres) {
 
     if (image.fb.m_vSize != monbox.size()) {
         image.fb.release();
-        image.fb.m_pStencilTex = nullptr;
         image.fb.alloc(monbox.w, monbox.h, pMonitor->output->state->state().drmFormat);
+        image.fb.addStencil(nullptr);
     }
 
     CRegion fakeDamage{0, 0, INT16_MAX, INT16_MAX};
@@ -400,7 +400,7 @@ void COverview::render() {
             texbox.scale(pMonitor->scale).translate(pos.value());
             texbox.round();
             CRegion damage{0, 0, INT16_MAX, INT16_MAX};
-            g_pHyprOpenGL->renderTextureInternalWithDamage(images[x + y * SIDE_LENGTH].fb.m_cTex, &texbox, 1.0, &damage);
+            g_pHyprOpenGL->renderTextureInternalWithDamage(images[x + y * SIDE_LENGTH].fb.getTexture(), &texbox, 1.0, &damage);
         }
     }
 }

--- a/hyprtrails/trail.cpp
+++ b/hyprtrails/trail.cpp
@@ -78,7 +78,7 @@ Vector2D vecForBezierT(const float& t, const std::vector<Vector2D>& verts) {
         return pts[0];
 }
 
-void CTrail::draw(PHLMONITOR pMonitor, float a) {
+void CTrail::draw(PHLMONITOR pMonitor, const float &a) {
     if (!validMapped(m_pWindow))
         return;
 


### PR DESCRIPTION
Somehow the last commit only included the changes to hpp, not to cpp, this PR adapts the `draw` function signature as in that commit. Not sure if other changes are required. It builds at least, except hyprexpo:

```
overview.cpp: In member function 'void COverview::render()':
overview.cpp:403:91: error: 'Hyprutils::Memory::CSharedPointer<CTexture> CFramebuffer::m_cTex' is private within this context
  403 |             g_pHyprOpenGL->renderTextureInternalWithDamage(images[x + y * SIDE_LENGTH].fb.m_cTex, &texbox, 1.0, &damage);
      |                                                                                           ^~~~~~
/usr/include/hyprland/src/render/Framebuffer.hpp:24:18: note: declared private here
   24 |     SP<CTexture> m_cTex;
      |                  ^~~~~~
```

The second commit also fixes that (for https://github.com/hyprwm/Hyprland/commit/40081cb330fa838ad9c0a7b87c20b2300ea7fb38)