### PR TITLE
Hyprbars: Fix typo in error message

### DIFF
--- a/hyprbars/main.cpp
+++ b/hyprbars/main.cpp
@@ -76,7 +76,7 @@ Hyprlang::CParseResult onNewButton(const char* K, const char* V) {
 
     auto X = configStringToInt(vars[0]);
     if (!X) {
-        result.setError("var2 is not a valid number");
+        result.setError("var0 is not a valid number");
         return result;
     }
     g_pGlobalState->buttons.push_back(SHyprButton{vars[3], *X, size, vars[2]});


### PR DESCRIPTION
This pull request includes a small fix to the error message in the `onNewButton` method of the `hyprbars/main.cpp` file. The change corrects the variable name referenced in the error message to accurately reflect the variable being validated. The error was missleading for me when configuring the plugin.

* Corrected the error message to reference `var0` instead of `var2` when `X` is not a valid number.