### PR TITLE
[hyprbars] Improve (touch + button) functionality

### DIFF
--- a/hyprbars/README.md
+++ b/hyprbars/README.md
@@ -53,7 +53,7 @@ plugin {
 Use the `hyprbars-button` keyword.
 
 ```ini
-hyprbars-button = color, size, icon, on-click
+hyprbars-button = bgcolor, size, icon, on-click, fgcolor
 ```
 
 ## Window rules

--- a/hyprbars/barDeco.cpp
+++ b/hyprbars/barDeco.cpp
@@ -411,11 +411,15 @@ void CHyprBar::renderBarButtons(const Vector2D& bufferSize, const float scale) {
     const auto         CAIROSURFACE = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, bufferSize.x, bufferSize.y);
     const auto         CAIRO        = cairo_create(CAIROSURFACE);
 
+
+    // clear the pixmap
     cairo_save(CAIRO);
     cairo_set_operator(CAIRO, CAIRO_OPERATOR_CLEAR);
     cairo_paint(CAIRO);
     cairo_restore(CAIRO);
 
+
+    // draw buttons
     int offset = **PBARPADDING * scale;
     for (size_t i = 0; i < visibleCount; ++i) {
         const auto& button           = g_pGlobalState->buttons[i];
@@ -431,6 +435,7 @@ void CHyprBar::renderBarButtons(const Vector2D& bufferSize, const float scale) {
         offset += scaledButtonsPad + scaledButtonSize;
     }
 
+    // copy the data to an OpenGL texture we have
     const auto DATA = cairo_image_surface_get_data(CAIROSURFACE);
     m_pButtonsTex->allocate();
     glBindTexture(GL_TEXTURE_2D, m_pButtonsTex->m_iTexID);
@@ -444,6 +449,7 @@ void CHyprBar::renderBarButtons(const Vector2D& bufferSize, const float scale) {
 
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, bufferSize.x, bufferSize.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, DATA);
 
+    // delete cairo
     cairo_destroy(CAIRO);
     cairo_surface_destroy(CAIROSURFACE);
 }
@@ -462,7 +468,8 @@ void CHyprBar::renderBarButtonsText(CBox* barBox, const float scale, const float
         const auto scaledButtonSize = button.size * scale;
         const auto scaledButtonsPad = **PBARBUTTONPADDING * scale;
 
-        if (button.iconTex->m_iTexID == 0 && !button.icon.empty()) {
+        if (button.iconTex->m_iTexID == 0 /* icon is not rendered */ && !button.icon.empty()) {
+            // render icon
             const Vector2D BUFSIZE = {scaledButtonSize, scaledButtonSize};
             auto           fgcol   = button.userfg ? button.fgcol : (button.bgcol.r + button.bgcol.g + button.bgcol.b < 1) ? CHyprColor(0xFFFFFFFF) : CHyprColor(0xFF000000);
 

--- a/hyprbars/barDeco.hpp
+++ b/hyprbars/barDeco.hpp
@@ -70,7 +70,7 @@ class CHyprBar : public IHyprWindowDecoration {
     void                      onTouchDown(SCallbackInfo& info, ITouch::SDownEvent e);
     void                      onTouchUp(SCallbackInfo& info, ITouch::SUpEvent e);
     void                      onTouchMove(SCallbackInfo& info, ITouch::SMotionEvent e);
-    void                      doButtonPress(auto PBARPADDING, auto PBARBUTTONPADDING, auto PHEIGHT, auto COORDS, bool BUTTONSRIGHT);
+    void                      doButtonPress(long int* const* PBARPADDING, long int* const* PBARBUTTONPADDING, long int* const* PHEIGHT, Vector2D COORDS, bool BUTTONSRIGHT);
     void                      onMouseMove(Vector2D coords);
     CBox                      assignedBoxGlobal();
 
@@ -89,7 +89,9 @@ class CHyprBar : public IHyprWindowDecoration {
     bool                      m_bCancelledDown = false;
 
     // for dynamic updates
-    int m_iLastHeight = 0;
+    int    m_iLastHeight = 0;
+
+    size_t getVisibleButtonCount(long int* const* PBARBUTTONPADDING, long int* const* PBARPADDING, const Vector2D& bufferSize, const float scale);
 
     friend class CBarPassElement;
 };

--- a/hyprbars/barDeco.hpp
+++ b/hyprbars/barDeco.hpp
@@ -5,7 +5,13 @@
 #include <hyprland/src/render/decorations/IHyprWindowDecoration.hpp>
 #include <hyprland/src/render/OpenGL.hpp>
 #include <hyprland/src/devices/IPointer.hpp>
+#include <hyprland/src/devices/ITouch.hpp>
+#include <hyprland/src/devices/Tablet.hpp>
 #include "globals.hpp"
+
+#define private public
+#include <hyprland/src/managers/input/InputManager.hpp>
+#undef private
 
 class CHyprBar : public IHyprWindowDecoration {
   public:
@@ -61,8 +67,16 @@ class CHyprBar : public IHyprWindowDecoration {
     void                      renderBarButtons(const Vector2D& bufferSize, const float scale);
     void                      renderBarButtonsText(CBox* barBox, const float scale, const float a);
     void                      onMouseDown(SCallbackInfo& info, IPointer::SButtonEvent e);
+    void                      onTouchDown(SCallbackInfo& info, ITouch::SDownEvent e);
+    void                      onTouchUp(SCallbackInfo& info, ITouch::SUpEvent e);
+    void                      onTouchMove(SCallbackInfo& info, ITouch::SMotionEvent e);
+    void                      doButtonPress(auto PBARPADDING, auto PBARBUTTONPADDING, auto PHEIGHT, auto COORDS, bool BUTTONSRIGHT);
     void                      onMouseMove(Vector2D coords);
     CBox                      assignedBoxGlobal();
+
+    SP<HOOK_CALLBACK_FN>      m_pTouchDownCallback;
+    SP<HOOK_CALLBACK_FN>      m_pTouchUpCallback;
+    SP<HOOK_CALLBACK_FN>      m_pTouchMoveCallback;
 
     SP<HOOK_CALLBACK_FN>      m_pMouseButtonCallback;
     SP<HOOK_CALLBACK_FN>      m_pMouseMoveCallback;
@@ -70,6 +84,7 @@ class CHyprBar : public IHyprWindowDecoration {
     std::string               m_szLastTitle;
 
     bool                      m_bDraggingThis  = false;
+    bool                      m_bTouchEv       = false;
     bool                      m_bDragPending   = false;
     bool                      m_bCancelledDown = false;
 

--- a/hyprbars/barDeco.hpp
+++ b/hyprbars/barDeco.hpp
@@ -66,13 +66,15 @@ class CHyprBar : public IHyprWindowDecoration {
     void                      renderBarButtons(const Vector2D& bufferSize, const float scale);
     void                      renderBarButtonsText(CBox* barBox, const float scale, const float a);
 
-    void                      onMouseDown(SCallbackInfo& info, IPointer::SButtonEvent e);
+    bool                      inputIsValid();
+    void                      onMouseButton(SCallbackInfo& info, IPointer::SButtonEvent e);
     void                      onTouchDown(SCallbackInfo& info, ITouch::SDownEvent e);
-    void                      onTouchUp(SCallbackInfo& info, ITouch::SUpEvent e);
-
     void                      onMouseMove(Vector2D coords);
     void                      onTouchMove(SCallbackInfo& info, ITouch::SMotionEvent e);
 
+    void                      handleDownEvent(SCallbackInfo& info, std::optional<ITouch::SDownEvent> touchEvent);
+    void                      handleUpEvent(SCallbackInfo& info);
+    void                      handleMovement();
     void                      doButtonPress(long int* const* PBARPADDING, long int* const* PBARBUTTONPADDING, long int* const* PHEIGHT, Vector2D COORDS, bool BUTTONSRIGHT);
 
     CBox                      assignedBoxGlobal();

--- a/hyprbars/barDeco.hpp
+++ b/hyprbars/barDeco.hpp
@@ -6,7 +6,6 @@
 #include <hyprland/src/render/OpenGL.hpp>
 #include <hyprland/src/devices/IPointer.hpp>
 #include <hyprland/src/devices/ITouch.hpp>
-#include <hyprland/src/devices/Tablet.hpp>
 #include "globals.hpp"
 
 #define private public
@@ -66,19 +65,23 @@ class CHyprBar : public IHyprWindowDecoration {
     void                      renderText(SP<CTexture> out, const std::string& text, const CHyprColor& color, const Vector2D& bufferSize, const float scale, const int fontSize);
     void                      renderBarButtons(const Vector2D& bufferSize, const float scale);
     void                      renderBarButtonsText(CBox* barBox, const float scale, const float a);
+
     void                      onMouseDown(SCallbackInfo& info, IPointer::SButtonEvent e);
     void                      onTouchDown(SCallbackInfo& info, ITouch::SDownEvent e);
     void                      onTouchUp(SCallbackInfo& info, ITouch::SUpEvent e);
-    void                      onTouchMove(SCallbackInfo& info, ITouch::SMotionEvent e);
-    void                      doButtonPress(long int* const* PBARPADDING, long int* const* PBARBUTTONPADDING, long int* const* PHEIGHT, Vector2D COORDS, bool BUTTONSRIGHT);
+
     void                      onMouseMove(Vector2D coords);
+    void                      onTouchMove(SCallbackInfo& info, ITouch::SMotionEvent e);
+
+    void                      doButtonPress(long int* const* PBARPADDING, long int* const* PBARBUTTONPADDING, long int* const* PHEIGHT, Vector2D COORDS, bool BUTTONSRIGHT);
+
     CBox                      assignedBoxGlobal();
 
+    SP<HOOK_CALLBACK_FN>      m_pMouseButtonCallback;
     SP<HOOK_CALLBACK_FN>      m_pTouchDownCallback;
     SP<HOOK_CALLBACK_FN>      m_pTouchUpCallback;
-    SP<HOOK_CALLBACK_FN>      m_pTouchMoveCallback;
 
-    SP<HOOK_CALLBACK_FN>      m_pMouseButtonCallback;
+    SP<HOOK_CALLBACK_FN>      m_pTouchMoveCallback;
     SP<HOOK_CALLBACK_FN>      m_pMouseMoveCallback;
 
     std::string               m_szLastTitle;

--- a/hyprbars/globals.hpp
+++ b/hyprbars/globals.hpp
@@ -7,7 +7,9 @@ inline HANDLE PHANDLE = nullptr;
 
 struct SHyprButton {
     std::string  cmd     = "";
-    CHyprColor   col     = CHyprColor(0, 0, 0, 0);
+    bool         userfg  = false;
+    CHyprColor   fgcol   = CHyprColor(0, 0, 0, 0);
+    CHyprColor   bgcol   = CHyprColor(0, 0, 0, 0);
     float        size    = 10;
     std::string  icon    = "";
     SP<CTexture> iconTex = makeShared<CTexture>();

--- a/hyprbars/main.cpp
+++ b/hyprbars/main.cpp
@@ -59,10 +59,10 @@ Hyprlang::CParseResult onNewButton(const char* K, const char* V) {
 
     Hyprlang::CParseResult result;
 
-    // hyprbars-button = color, size, icon, action
+    // hyprbars-button = bgcolor, size, icon, action, fgcolor
 
     if (vars[0].empty() || vars[1].empty()) {
-        result.setError("var 1 and 2 cannot be empty");
+        result.setError("bgcolor and size cannot be empty");
         return result;
     }
 
@@ -70,16 +70,30 @@ Hyprlang::CParseResult onNewButton(const char* K, const char* V) {
     try {
         size = std::stof(vars[1]);
     } catch (std::exception& e) {
-        result.setError("failed parsing var 2 as int");
+        result.setError("failed to parse size");
         return result;
     }
 
-    auto X = configStringToInt(vars[0]);
-    if (!X) {
-        result.setError("var0 is not a valid number");
+    bool userfg  = false;
+    auto fgcolor = configStringToInt("rgb(ffffff)");
+    auto bgcolor = configStringToInt(vars[1]);
+
+    if (!bgcolor) {
+        result.setError("invalid bgcolor");
         return result;
     }
-    g_pGlobalState->buttons.push_back(SHyprButton{vars[3], *X, size, vars[2]});
+
+    if (vars.size() == 5) {
+        userfg  = true;
+        fgcolor = configStringToInt(vars[4]);
+    }
+
+    if (!fgcolor) {
+        result.setError("invalid fgcolor");
+        return result;
+    }
+
+    g_pGlobalState->buttons.push_back(SHyprButton{vars[3], userfg, *fgcolor, *bgcolor, size, vars[2]});
 
     for (auto& b : g_pGlobalState->bars) {
         b->m_bButtonsDirty = true;

--- a/hyprbars/main.cpp
+++ b/hyprbars/main.cpp
@@ -6,6 +6,7 @@
 #include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/desktop/Window.hpp>
 #include <hyprland/src/config/ConfigManager.hpp>
+#include <hyprland/src/render/Renderer.hpp>
 
 #include "barDeco.hpp"
 #include "globals.hpp"
@@ -155,4 +156,6 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 APICALL EXPORT void PLUGIN_EXIT() {
     for (auto& m : g_pCompositor->m_vMonitors)
         m->scheduledRecalc = true;
+
+    g_pHyprRenderer->m_sRenderPass.removeAllOfType("CBarPassElement");
 }

--- a/hyprexpo/overview.cpp
+++ b/hyprexpo/overview.cpp
@@ -95,9 +95,12 @@ COverview::COverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn
     timespec now;
     clock_gettime(CLOCK_MONOTONIC, &now);
 
-    Vector2D     tileSize       = pMonitor->vecSize / SIDE_LENGTH;
-    Vector2D     tileRenderSize = (pMonitor->vecSize - Vector2D{GAP_WIDTH * pMonitor->scale, GAP_WIDTH * pMonitor->scale} * (SIDE_LENGTH - 1)) / SIDE_LENGTH;
-    CBox         monbox{0, 0, tileSize.x * 2, tileSize.y * 2};
+    Vector2D tileSize       = pMonitor->vecSize / SIDE_LENGTH;
+    Vector2D tileRenderSize = (pMonitor->vecSize - Vector2D{GAP_WIDTH * pMonitor->scale, GAP_WIDTH * pMonitor->scale} * (SIDE_LENGTH - 1)) / SIDE_LENGTH;
+    CBox     monbox{0, 0, tileSize.x * 2, tileSize.y * 2};
+
+    if (!ENABLE_LOWRES)
+        monbox = {{0, 0}, pMonitor->vecPixelSize};
 
     int          currentid = 0;
 
@@ -403,7 +406,7 @@ void COverview::fullRender() {
             texbox.scale(pMonitor->scale).translate(pos.value());
             texbox.round();
             CRegion damage{0, 0, INT16_MAX, INT16_MAX};
-            g_pHyprOpenGL->renderTextureInternalWithDamage(images[x + y * SIDE_LENGTH].fb.getTexture(), &texbox, 1.0, damage);
+            g_pHyprOpenGL->renderTextureInternalWithDamage(images[x + y * SIDE_LENGTH].fb.getTexture(), &texbox, 1.0, damage, 0, false, false, false, false, nullptr, 0);
         }
     }
 }


### PR DESCRIPTION
Task list:
- [x] Ability to customise the foreground colour of the icons
- [x] Ability to use the buttons with touch devices
- [x] Ability to move the window using the bar with touch devices
- [x] ~~Further testing required for touch+cancel events (described below)~~ vaxry fixed it lmao
- [x] Only render visible icons
- ~~Implement tablet/pen support~~, not looking very easy, will prob be done in another mr.

Note that as of 31/12/24 i no longer have access to a touch screen device in order to test touch functionality (it is being repaired).

~~(description below): There appears to be a bug where touching outside the main application (e.g. the border or the bar, i.e. A part of the window attached to the window but not the main application) causes touch down/click events to be sent to the application (?) which can open things like context menus.~~ again, fixed by the man himself (vaxry)