### PR TITLE
Fix `renderTextureInternalWithDamage` call for new parameter

### DIFF
--- a/hyprexpo/overview.cpp
+++ b/hyprexpo/overview.cpp
@@ -406,7 +406,7 @@ void COverview::fullRender() {
             texbox.scale(pMonitor->scale).translate(pos.value());
             texbox.round();
             CRegion damage{0, 0, INT16_MAX, INT16_MAX};
-            g_pHyprOpenGL->renderTextureInternalWithDamage(images[x + y * SIDE_LENGTH].fb.getTexture(), &texbox, 1.0, damage, 0, false, false, false, false, nullptr, 0);
+            g_pHyprOpenGL->renderTextureInternalWithDamage(images[x + y * SIDE_LENGTH].fb.getTexture(), &texbox, 1.0, damage);
         }
     }
 }


### PR DESCRIPTION
Re: https://github.com/hyprwm/Hyprland/commit/a5c14370c11287cbf520c8f427179c665ac9c891

I've opted to remove the optional parameters, since they match the defaults, so unless there is a specific reason for explicitly setting them this is easier