### PR TITLE
all: add new `roundingPower` parameter to render function calls

### DIFF
--- a/borders-plus-plus/borderDeco.cpp
+++ b/borders-plus-plus/borderDeco.cpp
@@ -100,6 +100,7 @@ void CBordersPlusPlus::drawPass(PHLMONITOR pMonitor, const float& a) {
     const auto WORKSPACEOFFSET = PWORKSPACE && !PWINDOW->m_bPinned ? PWORKSPACE->m_vRenderOffset->value() : Vector2D();
 
     auto       rounding      = PWINDOW->rounding() == 0 ? 0 : (PWINDOW->rounding() + **PBORDERSIZE) * pMonitor->scale;
+    const auto ROUNDINGPOWER = PWINDOW->roundingPower();
     const auto ORIGINALROUND = rounding == 0 ? 0 : (PWINDOW->rounding() + **PBORDERSIZE) * pMonitor->scale;
 
     CBox       fullBox = m_bAssignedGeometry;
@@ -136,7 +137,7 @@ void CBordersPlusPlus::drawPass(PHLMONITOR pMonitor, const float& a) {
 
         g_pHyprOpenGL->scissor((CBox*)nullptr);
 
-        g_pHyprOpenGL->renderBorder(&fullBox, CHyprColor{(uint64_t)**PCOLORS[i]}, **PNATURALROUND ? ORIGINALROUND : rounding, THISBORDERSIZE, a,
+        g_pHyprOpenGL->renderBorder(&fullBox, CHyprColor{(uint64_t)**PCOLORS[i]}, **PNATURALROUND ? ORIGINALROUND : rounding, ROUNDINGPOWER, THISBORDERSIZE, a,
                                     **PNATURALROUND ? ORIGINALROUND : -1);
     }
 

--- a/hyprtrails/trail.cpp
+++ b/hyprtrails/trail.cpp
@@ -120,7 +120,7 @@ void CTrail::renderPass(PHLMONITOR pMonitor, const float& a) {
     glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
 
     glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
-    g_pHyprOpenGL->renderRect(&wlrbox, CHyprColor(0, 0, 0, 0), PWINDOW->rounding() * pMonitor->scale);
+    g_pHyprOpenGL->renderRect(&wlrbox, CHyprColor(0, 0, 0, 0), PWINDOW->rounding() * pMonitor->scale, PWINDOW->roundingPower());
     glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 
     glStencilFunc(GL_NOTEQUAL, 1, -1);


### PR DESCRIPTION
Fixes broken Hyprland function calls that were changed in hyprwm/Hyprland#8943.

Should fix #270.