### PR TITLE
Hyprbars: disable drag when clicking button

### DIFF
--- a/hyprbars/barDeco.cpp
+++ b/hyprbars/barDeco.cpp
@@ -162,9 +162,8 @@ void CHyprBar::handleDownEvent(SCallbackInfo& info, std::optional<ITouch::SDownE
     info.cancelled   = true;
     m_bCancelledDown = true;
 
-    doButtonPress(PBARPADDING, PBARBUTTONPADDING, PHEIGHT, COORDS, BUTTONSRIGHT);
-
-    m_bDragPending = true;
+    if (!doButtonPress(PBARPADDING, PBARBUTTONPADDING, PHEIGHT, COORDS, BUTTONSRIGHT))
+        m_bDragPending = true;
 }
 
 void CHyprBar::handleUpEvent(SCallbackInfo& info) {
@@ -194,7 +193,7 @@ void CHyprBar::handleMovement() {
     return;
 }
 
-void CHyprBar::doButtonPress(long int* const* PBARPADDING, long int* const* PBARBUTTONPADDING, long int* const* PHEIGHT, Vector2D COORDS, const bool BUTTONSRIGHT) {
+bool CHyprBar::doButtonPress(long int* const* PBARPADDING, long int* const* PBARBUTTONPADDING, long int* const* PHEIGHT, Vector2D COORDS, const bool BUTTONSRIGHT) {
     //check if on a button
     float offset = **PBARPADDING;
 
@@ -205,11 +204,12 @@ void CHyprBar::doButtonPress(long int* const* PBARPADDING, long int* const* PBAR
         if (VECINRECT(COORDS, currentPos.x, currentPos.y, currentPos.x + b.size + **PBARBUTTONPADDING, currentPos.y + b.size)) {
             // hit on close
             g_pKeybindManager->m_mDispatchers["exec"](b.cmd);
-            return;
+            return true;
         }
 
         offset += **PBARBUTTONPADDING + b.size;
     }
+    return false;
 }
 
 void CHyprBar::renderText(SP<CTexture> out, const std::string& text, const CHyprColor& color, const Vector2D& bufferSize, const float scale, const int fontSize) {

--- a/hyprbars/barDeco.hpp
+++ b/hyprbars/barDeco.hpp
@@ -78,7 +78,7 @@ class CHyprBar : public IHyprWindowDecoration {
     void                      handleDownEvent(SCallbackInfo& info, std::optional<ITouch::SDownEvent> touchEvent);
     void                      handleUpEvent(SCallbackInfo& info);
     void                      handleMovement();
-    void                      doButtonPress(long int* const* PBARPADDING, long int* const* PBARBUTTONPADDING, long int* const* PHEIGHT, Vector2D COORDS, bool BUTTONSRIGHT);
+    bool                      doButtonPress(long int* const* PBARPADDING, long int* const* PBARBUTTONPADDING, long int* const* PHEIGHT, Vector2D COORDS, bool BUTTONSRIGHT);
 
     CBox                      assignedBoxGlobal();
 


### PR DESCRIPTION
When clicking buttons on hyprbars, it doesn't disable drag, which causes problems if the click opens a new window/dialog as shown in the video.
first part of the video is the current behavior and second part is with this change.

https://github.com/user-attachments/assets/a977fb8e-a2f0-4ca0-9980-0d62389271e7

Edit: didn't see there was an issue, fixes #284 
