### PR TITLE
Hyprbars: center button text

### DIFF
--- a/hyprbars/barDeco.cpp
+++ b/hyprbars/barDeco.cpp
@@ -162,9 +162,8 @@ void CHyprBar::handleDownEvent(SCallbackInfo& info, std::optional<ITouch::SDownE
     info.cancelled   = true;
     m_bCancelledDown = true;
 
-    doButtonPress(PBARPADDING, PBARBUTTONPADDING, PHEIGHT, COORDS, BUTTONSRIGHT);
-
-    m_bDragPending = true;
+    if (!doButtonPress(PBARPADDING, PBARBUTTONPADDING, PHEIGHT, COORDS, BUTTONSRIGHT))
+        m_bDragPending = true;
 }
 
 void CHyprBar::handleUpEvent(SCallbackInfo& info) {
@@ -194,7 +193,7 @@ void CHyprBar::handleMovement() {
     return;
 }
 
-void CHyprBar::doButtonPress(long int* const* PBARPADDING, long int* const* PBARBUTTONPADDING, long int* const* PHEIGHT, Vector2D COORDS, const bool BUTTONSRIGHT) {
+bool CHyprBar::doButtonPress(long int* const* PBARPADDING, long int* const* PBARBUTTONPADDING, long int* const* PHEIGHT, Vector2D COORDS, const bool BUTTONSRIGHT) {
     //check if on a button
     float offset = **PBARPADDING;
 
@@ -205,11 +204,12 @@ void CHyprBar::doButtonPress(long int* const* PBARPADDING, long int* const* PBAR
         if (VECINRECT(COORDS, currentPos.x, currentPos.y, currentPos.x + b.size + **PBARBUTTONPADDING, currentPos.y + b.size)) {
             // hit on close
             g_pKeybindManager->m_mDispatchers["exec"](b.cmd);
-            return;
+            return true;
         }
 
         offset += **PBARBUTTONPADDING + b.size;
     }
+    return false;
 }
 
 void CHyprBar::renderText(SP<CTexture> out, const std::string& text, const CHyprColor& color, const Vector2D& bufferSize, const float scale, const int fontSize) {

--- a/hyprbars/barDeco.cpp
+++ b/hyprbars/barDeco.cpp
@@ -238,8 +238,12 @@ void CHyprBar::renderText(SP<CTexture> out, const std::string& text, const CHypr
 
     cairo_set_source_rgba(CAIRO, color.r, color.g, color.b, color.a);
 
-    int layoutWidth, layoutHeight;
-    pango_layout_get_size(layout, &layoutWidth, &layoutHeight);
+    PangoRectangle ink_rect, logical_rect;
+    pango_layout_get_extents(layout, &ink_rect, &logical_rect);
+
+    const int    layoutWidth  = ink_rect.width;
+    const int    layoutHeight = logical_rect.height;
+
     const double xOffset = (bufferSize.x / 2.0 - layoutWidth / PANGO_SCALE / 2.0);
     const double yOffset = (bufferSize.y / 2.0 - layoutHeight / PANGO_SCALE / 2.0);
 

--- a/hyprbars/barDeco.hpp
+++ b/hyprbars/barDeco.hpp
@@ -78,7 +78,7 @@ class CHyprBar : public IHyprWindowDecoration {
     void                      handleDownEvent(SCallbackInfo& info, std::optional<ITouch::SDownEvent> touchEvent);
     void                      handleUpEvent(SCallbackInfo& info);
     void                      handleMovement();
-    void                      doButtonPress(long int* const* PBARPADDING, long int* const* PBARBUTTONPADDING, long int* const* PHEIGHT, Vector2D COORDS, bool BUTTONSRIGHT);
+    bool                      doButtonPress(long int* const* PBARPADDING, long int* const* PBARBUTTONPADDING, long int* const* PHEIGHT, Vector2D COORDS, bool BUTTONSRIGHT);
 
     CBox                      assignedBoxGlobal();
 


### PR DESCRIPTION
Some unicode characters didn't center properly, changing the width calculation to ink_rect fixes it, but it doesn't work for height too, so i kept logical_rect for height (same value from before, `pango_layout_get_size` returns the logical_rect).

before:
![uncentered](https://github.com/user-attachments/assets/0e6b94a9-884f-4360-abb3-5251427aa399)

after:
![centered](https://github.com/user-attachments/assets/2f98b23c-56e7-428b-a555-e9672ffba7f7)
