### PR TITLE
Hyprbars: center button text

### DIFF
--- a/hyprbars/barDeco.cpp
+++ b/hyprbars/barDeco.cpp
@@ -238,8 +238,12 @@ void CHyprBar::renderText(SP<CTexture> out, const std::string& text, const CHypr
 
     cairo_set_source_rgba(CAIRO, color.r, color.g, color.b, color.a);
 
-    int layoutWidth, layoutHeight;
-    pango_layout_get_size(layout, &layoutWidth, &layoutHeight);
+    PangoRectangle ink_rect, logical_rect;
+    pango_layout_get_extents(layout, &ink_rect, &logical_rect);
+
+    const int    layoutWidth  = ink_rect.width;
+    const int    layoutHeight = logical_rect.height;
+
     const double xOffset = (bufferSize.x / 2.0 - layoutWidth / PANGO_SCALE / 2.0);
     const double yOffset = (bufferSize.y / 2.0 - layoutHeight / PANGO_SCALE / 2.0);
 


### PR DESCRIPTION
Some unicode characters didn't center properly, changing the width calculation to ink_rect fixes it, but it doesn't work for height too, so i kept logical_rect for height (same value from before, `pango_layout_get_size` [gets values from the logical_rect](https://docs.gtk.org/Pango/method.Layout.get_size.html)).

before:
![uncentered](https://github.com/user-attachments/assets/0e6b94a9-884f-4360-abb3-5251427aa399)

after:
![centered](https://github.com/user-attachments/assets/2f98b23c-56e7-428b-a555-e9672ffba7f7)

i think i saw some issue about it but can't find it now, maybe it was some other issue and someone just left a comment about it.

edit: add pic if using ink_rect for height:
![ink-height](https://github.com/user-attachments/assets/a6fa74db-14f1-4fc9-ae8e-d1b47c6b0916)

