### PR TITLE
Hyprbars: fix title rendering for RTL text

### DIFF
--- a/hyprbars/barDeco.cpp
+++ b/hyprbars/barDeco.cpp
@@ -319,6 +319,9 @@ void CHyprBar::renderBarTitle(const Vector2D& bufferSize, const float scale) {
     pango_layout_set_font_description(layout, fontDesc);
     pango_font_description_free(fontDesc);
 
+    PangoContext* context = pango_layout_get_context(layout);
+    pango_context_set_base_dir(context, PANGO_DIRECTION_NEUTRAL);
+
     const int paddingTotal = scaledBarPadding * 2 + scaledButtonsSize + (std::string{*PALIGN} != "left" ? scaledButtonsSize : 0);
     const int maxWidth     = std::clamp(static_cast<int>(bufferSize.x - paddingTotal), 0, INT_MAX);
 


### PR DESCRIPTION
Sets pango's base direction to netural for rendering title, fixes #285 

before:
#285 

after:
`bar_text_align = center`
![Screenshot_2025-03-16_22-54-15](https://github.com/user-attachments/assets/3b3e096a-3d13-4bb1-b42e-2cd00182994f)

![Screenshot_2025-03-16_22-54-35](https://github.com/user-attachments/assets/fdf64341-4a54-4645-b8a6-740b5605d587)

`bar_text_align = left`
![Screenshot_2025-03-16_22-59-28](https://github.com/user-attachments/assets/9e35ea07-4fea-4ffa-9f4c-ba46f4bd042f)

![Screenshot_2025-03-16_22-59-48](https://github.com/user-attachments/assets/14df6b03-be37-4d1f-851d-2a59af331db7)
