### PR TITLE
Draft: hyprbars: Don't react to touch events with mismatching touchID

### DIFF
--- a/hyprbars/barDeco.hpp
+++ b/hyprbars/barDeco.hpp
@@ -75,6 +75,7 @@ class CHyprBar : public IHyprWindowDecoration {
     bool                      inputIsValid();
     void                      onMouseButton(SCallbackInfo& info, IPointer::SButtonEvent e);
     void                      onTouchDown(SCallbackInfo& info, ITouch::SDownEvent e);
+    void                      onTouchUp(SCallbackInfo& info, ITouch::SUpEvent e);
     void                      onMouseMove(Vector2D coords);
     void                      onTouchMove(SCallbackInfo& info, ITouch::SMotionEvent e);
 
@@ -98,6 +99,7 @@ class CHyprBar : public IHyprWindowDecoration {
     bool                      m_bTouchEv       = false;
     bool                      m_bDragPending   = false;
     bool                      m_bCancelledDown = false;
+    int                       m_touchId        = 0;
 
     // for dynamic updates
     int    m_iLastHeight = 0;


### PR DESCRIPTION
so you can do things with your other fingers (such as switch workspaces with the `workspace_swipe_touch`

This is marked as a draft because currently using another finger sometimes causes the window to jump to that finger. I think hyprland internally needs a way to move a window using a touch event instead of having touches sometimes turn into cursor movement.