### PR TITLE
hyprbars: invalidate input when overlay and top shell layers are on top

### DIFF
--- a/hyprbars/barDeco.cpp
+++ b/hyprbars/barDeco.cpp
@@ -9,6 +9,7 @@
 #include <hyprland/src/managers/LayoutManager.hpp>
 #include <hyprland/src/config/ConfigManager.hpp>
 #include <hyprland/src/managers/AnimationManager.hpp>
+#include <hyprland/src/protocols/LayerShell.hpp>
 #include <pango/pangocairo.h>
 
 #include "globals.hpp"
@@ -90,6 +91,18 @@ bool CHyprBar::inputIsValid() {
     const auto WINDOWATCURSOR = g_pCompositor->vectorToWindowUnified(g_pInputManager->getMouseCoordsInternal(), RESERVED_EXTENTS | INPUT_EXTENTS | ALLOW_FLOATING);
 
     if (WINDOWATCURSOR != m_pWindow && m_pWindow != g_pCompositor->m_lastWindow)
+        return false;
+
+    // check if input is on top or overlay shell layers
+    auto PMONITOR                  = g_pCompositor->m_lastMonitor.lock();
+    PHLLS foundOverlayLayerSurface = nullptr;
+    PHLLS foundTopLayerSurface     = nullptr;
+    Vector2D surfaceCoords;
+
+    g_pCompositor->vectorToLayerSurface(g_pInputManager->getMouseCoordsInternal(), &PMONITOR->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY], &surfaceCoords, &foundOverlayLayerSurface);
+    g_pCompositor->vectorToLayerSurface(g_pInputManager->getMouseCoordsInternal(), &PMONITOR->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP], &surfaceCoords, &foundTopLayerSurface);
+
+    if (foundOverlayLayerSurface || foundTopLayerSurface)
         return false;
 
     return true;

--- a/hyprbars/barDeco.cpp
+++ b/hyprbars/barDeco.cpp
@@ -95,14 +95,18 @@ bool CHyprBar::inputIsValid() {
 
     // check if input is on top or overlay shell layers
     auto PMONITOR                  = g_pCompositor->m_lastMonitor.lock();
-    PHLLS foundOverlayLayerSurface = nullptr;
-    PHLLS foundTopLayerSurface     = nullptr;
+    PHLLS foundSurface             = nullptr;
     Vector2D surfaceCoords;
 
-    g_pCompositor->vectorToLayerSurface(g_pInputManager->getMouseCoordsInternal(), &PMONITOR->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY], &surfaceCoords, &foundOverlayLayerSurface);
-    g_pCompositor->vectorToLayerSurface(g_pInputManager->getMouseCoordsInternal(), &PMONITOR->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP], &surfaceCoords, &foundTopLayerSurface);
+    // check top layer
+    g_pCompositor->vectorToLayerSurface(g_pInputManager->getMouseCoordsInternal(), &PMONITOR->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP], &surfaceCoords, &foundSurface);
 
-    if (foundOverlayLayerSurface || foundTopLayerSurface)
+    if (foundSurface)
+        return false;
+    // check overlay layer
+    g_pCompositor->vectorToLayerSurface(g_pInputManager->getMouseCoordsInternal(), &PMONITOR->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY], &surfaceCoords, &foundSurface);
+
+    if (foundSurface)
         return false;
 
     return true;


### PR DESCRIPTION
Fix #373 