### PR TITLE
expo: add dispatcher argument to select currently hovered workspace

### DIFF
--- a/hyprexpo/README.md
+++ b/hyprexpo/README.md
@@ -6,7 +6,7 @@ Overview plugin like gnome kde or wf.
 
 ```ini
 
-bind = SUPER, grave, hyprexpo:expo, toggle # can be: toggle, off/disable or on/enable
+bind = SUPER, grave, hyprexpo:expo, toggle # can be: toggle, select, off/disable or on/enable
 
 plugin {
     hyprexpo {

--- a/hyprexpo/main.cpp
+++ b/hyprexpo/main.cpp
@@ -130,6 +130,13 @@ static void onExpoDispatcher(std::string arg) {
 
     if (swipeActive)
         return;
+    if (arg == "select") { 
+        if (g_pOverview) {
+            g_pOverview->selectHoveredWorkspace();
+            g_pOverview->close();
+        }
+        return;
+    }
     if (arg == "toggle") {
         if (g_pOverview)
             g_pOverview->close();

--- a/hyprexpo/overview.cpp
+++ b/hyprexpo/overview.cpp
@@ -214,6 +214,16 @@ COverview::COverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn
     touchDownHook   = g_pHookSystem->hookDynamic("touchDown", onCursorSelect);
 }
 
+void COverview::selectHoveredWorkspace() {
+    if (closing)
+        return;
+
+    // get tile x,y
+    int x = lastMousePosLocal.x / pMonitor->m_size.x * SIDE_LENGTH;
+    int y = lastMousePosLocal.y / pMonitor->m_size.y * SIDE_LENGTH;
+    closeOnID = x + y * SIDE_LENGTH;
+}
+
 void COverview::redrawID(int id, bool forcelowres) {
     if (pMonitor->m_activeWorkspace != startedOn && !closing) {
         // likely user changed.

--- a/hyprexpo/overview.hpp
+++ b/hyprexpo/overview.hpp
@@ -30,6 +30,7 @@ class COverview {
 
     // close without a selection
     void          close();
+    void          selectHoveredWorkspace();
 
     bool          blockOverviewRendering = false;
     bool          blockDamageReporting   = false;


### PR DESCRIPTION
As the title says, i added a dispatcher argument "select" to select the currently hovered workspace.
This solves #361 