### PR TITLE
add install notes to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,30 +2,6 @@
 
 This repo houses official plugins for Hyprland.
 
-> [!IMPORTANT]
-> hyprland-plugins only officially supports installation via `hyprpm`.
-> hyprland-plugins follows hyprland-git and requires you to be on hyprland-git
-> or tagged >= v0.33.1.
-
-To install these plugins, first 
-```bash
-hyprpm update
-```
-Then add this repository:
-
-```bash
-hyprpm add https://github.com/hyprwm/hyprland-plugins
-```
-
-then enable the desired plugin with
-```bash
-hyprpm enable <plugin-name>
-```
-
-See the respective README's in the subdirectories for configuration options.
-
-See [the plugins wiki](https://wiki.hyprland.org/Plugins/Using-Plugins/#installing--using-plugins) and `hyprpm -h` for more details.
-
 # Plugin list
  - borders-plus-plus -> adds one or two additional borders to windows
  - csgo-vulkan-fix -> fixes custom resolutions on CS:GO with `-vulkan`
@@ -36,7 +12,32 @@ See [the plugins wiki](https://wiki.hyprland.org/Plugins/Using-Plugins/#installi
  - hyprwinwrap -> clone of xwinwrap, allows you to put any app as a wallpaper
  - xtra-dispatchers -> adds some new dispatchers
 
-## Installation on Nix
+# Install
+> [!IMPORTANT]
+> hyprland-plugins only officially supports installation via `hyprpm`.
+> hyprland-plugins follows hyprland-git and requires you to be on hyprland-git
+> or tagged >= v0.33.1.
+
+## Install with `hyprpm`
+
+To install these plugins, from the command line run:
+```bash
+hyprpm update
+```
+Then add this repository:
+```bash
+hyprpm add https://github.com/hyprwm/hyprland-plugins
+```
+then enable the desired plugin with
+```bash
+hyprpm enable <plugin-name>
+```
+
+See the respective README's in the subdirectories for configuration options.
+
+See [the plugins wiki](https://wiki.hyprland.org/Plugins/Using-Plugins/#installing--using-plugins) and `hyprpm -h` for more details.
+
+## Install on Nix
 
 To use these plugins, it's recommended that you are already using the
 [Hyprland flake](https://github.com/hyprwm/Hyprland).


### PR DESCRIPTION
I was confused when trying to install my first plugin, even after reading the wiki page. Maybe these changes make other people struggle less in the future?

Ultimately, I posted the below on Discord to figure it out:

> Hey I'm relatively new to hyprland, was on sway before and i3 before that. [my dots](https://github.com/japhir/ArchConfigs/).
> 
> I would like to try out the hyprscroller plugin, but the [overview page](https://github.com/hyprwm/hyprland-plugins/) was unclear to me. Firstly, it wasn't clear that the hyprpm command was already pre-installed with the package (at least on Arch) and the hyprland-plugins README or any of the component readme's don't link to hyprmp (and there is no man hyprpm) or have installation instructions except for some Nix instructions.
> 
> Ultimately I found `hyprpm -h` and the [wiki on how to install plugins](https://wiki.hyprland.org/Plugins/Using-Plugins/#installing--using-plugins). However, when I run `hyprpm add https://github.com/hyprwm/hyprland-plugins` I get the below error that doesn't show up anywhere when searching for it:
> ```
> ! Disclaimer: 
> plugins, especially not official, have no guarantee of stability, availablity or security.
> Run them at your own risk.
> This message will not appear again.
> 
> [ERR] ✖ Failed to write plugin state
> ```
> any help would be appreciated!

Thanks to the help of ergon._. I was able to figure out I had to run `hyprpm update` first.

I thought I'd contribute this. Then hopefully others could maybe tackle the [showcase page with the plugins](https://hyprland.org/plugins/), which IMO could link to the [wiki page on how to use/install plugins](https://github.com/hyprwm/hyprland-plugins/). Then the wiki page could mention that hyprpm is a command line utility included with hyprland, and that you first need to run `hyprpm update` before running, e.g. `hyprpm add XX`.

