### PR TITLE
Add `inactive_button_color` option

### DIFF
--- a/hyprbars/README.md
+++ b/hyprbars/README.md
@@ -52,6 +52,8 @@ plugin {
 
 `icon_on_hover` -> (bool) whether the icons show on mouse hovering over the buttons (default `false`)
 
+`inactive_button_color` -> (col) buttons bg color when window isn't focused
+
 ## Buttons Config
 
 Use the `hyprbars-button` keyword.

--- a/hyprbars/barDeco.cpp
+++ b/hyprbars/barDeco.cpp
@@ -417,6 +417,7 @@ void CHyprBar::renderBarButtons(const Vector2D& bufferSize, const float scale) {
     static auto* const PBARBUTTONPADDING = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_button_padding")->getDataStaticPtr();
     static auto* const PBARPADDING       = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_padding")->getDataStaticPtr();
     static auto* const PALIGNBUTTONS     = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_buttons_alignment")->getDataStaticPtr();
+    static auto* const PINACTIVECOLOR    = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:inactive_button_color")->getDataStaticPtr();
 
     const bool         BUTTONSRIGHT = std::string{*PALIGNBUTTONS} != "left";
     const auto         visibleCount = getVisibleButtonCount(PBARBUTTONPADDING, PBARPADDING, bufferSize, scale);
@@ -438,8 +439,15 @@ void CHyprBar::renderBarButtons(const Vector2D& bufferSize, const float scale) {
         const auto  scaledButtonsPad = **PBARBUTTONPADDING * scale;
 
         const auto  pos = Vector2D{BUTTONSRIGHT ? bufferSize.x - offset - scaledButtonSize / 2.0 : offset + scaledButtonSize / 2.0, bufferSize.y / 2.0}.floor();
+        auto      color = button.bgcol;
 
-        cairo_set_source_rgba(CAIRO, button.bgcol.r, button.bgcol.g, button.bgcol.b, button.bgcol.a);
+        if (**PINACTIVECOLOR > 0) {
+            color = m_bWindowHasFocus ? color : CHyprColor(**PINACTIVECOLOR);
+            if (button.userfg && button.iconTex->m_texID != 0)
+                button.iconTex->destroyTexture();
+        }
+
+        cairo_set_source_rgba(CAIRO, color.r, color.g, color.b, color.a);
         cairo_arc(CAIRO, pos.x, pos.y, scaledButtonSize / 2, 0, 2 * M_PI);
         cairo_fill(CAIRO);
 
@@ -547,6 +555,15 @@ void CHyprBar::renderPass(PHLMONITOR pMonitor, const float& a) {
     static auto* const PENABLETITLE      = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_title_enabled")->getDataStaticPtr();
     static auto* const PENABLEBLUR       = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_blur")->getDataStaticPtr();
     static auto* const PENABLEBLURGLOBAL = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "decoration:blur:enabled")->getDataStaticPtr();
+    static auto* const PINACTIVECOLOR    = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:inactive_button_color")->getDataStaticPtr();
+
+    if (**PINACTIVECOLOR > 0) {
+        bool currentWindowFocus = PWINDOW == g_pCompositor->m_lastWindow.lock();
+        if (currentWindowFocus != m_bWindowHasFocus) {
+            m_bWindowHasFocus = currentWindowFocus;
+            m_bButtonsDirty = true;
+        }
+    }
 
     const CHyprColor   DEST_COLOR = m_bForcedBarColor.value_or(**PCOLOR);
     if (DEST_COLOR != m_cRealBarColor->goal())

--- a/hyprbars/barDeco.hpp
+++ b/hyprbars/barDeco.hpp
@@ -61,6 +61,7 @@ class CHyprBar : public IHyprWindowDecoration {
     bool                      m_bTitleColorChanged = false;
     bool                      m_bButtonHovered     = false;
     bool                      m_bLastEnabledState  = false;
+    bool                      m_bWindowHasFocus    = false;
     std::optional<CHyprColor> m_bForcedBarColor;
     std::optional<CHyprColor> m_bForcedTitleColor;
 

--- a/hyprbars/main.cpp
+++ b/hyprbars/main.cpp
@@ -142,6 +142,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_button_padding", Hyprlang::INT{5});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:enabled", Hyprlang::INT{1});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:icon_on_hover", Hyprlang::INT{0});
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:inactive_button_color", Hyprlang::INT{0}); // unset
 
     HyprlandAPI::addConfigKeyword(PHANDLE, "hyprbars-button", onNewButton, Hyprlang::SHandlerOptions{});
     static auto P4 = HyprlandAPI::registerCallbackDynamic(PHANDLE, "preConfigReload", [&](void* self, SCallbackInfo& info, std::any data) { onPreConfigReload(); });


### PR DESCRIPTION
Not sure about the proper option name. But this adds a way to customize the bg color of buttons on unfocused windows.