### PR TITLE
Added swapcol and dispatchers to hyprscrolling

### DIFF
--- a/hyprscrolling/README.md
+++ b/hyprscrolling/README.md
@@ -14,7 +14,7 @@ Adds a scrolling layout to Hyprland.
 | column_width | default column width as a fraction of the monitor width | float [0 - 1] | 0.5 |
 | explicit_column_widths | a comma-separated list of widths for columns to be used with `+conf` or `-conf` | string | `0.333, 0.5, 0.667, 1.0` |
 | focus_fit_method | when a column is focused, what method to use to bring it into view. 0 - center, 1 - fit | int | 0 |
-
+| center_on_focus | always keep the currently focused window in the center | bool | false |
 
 ## Layout messages
 
@@ -26,3 +26,10 @@ Adds a scrolling layout to Hyprland.
 | fit | executes a fit operation based on the argument. Available: `active`, `visible`, `all`, `toend`, `tobeg` | fit mode |
 | focus | moves the focus and centers the layout, while also wrapping instead of moving to neighbring monitors. | direction |
 | promote | moves a window to its own new column | none |
+| swapcol | swap the current column with a neighbor. `l`/`r`| direction |
+
+## With dispatchers
+`hyprctl dispatch colresize +conf`
+
+## With bindings
+`bind = SUPER, left, focus, l`

--- a/hyprscrolling/Scrolling.cpp
+++ b/hyprscrolling/Scrolling.cpp
@@ -985,7 +985,7 @@ std::any CScrollingLayout::layoutMessage(SLayoutMessageHeader header, std::strin
   ELIF_CHAIN("fit", fit(message.substr(message.find(' ') + 1)))
   ELIF_CHAIN("focus", focus(args[1]))
   ELIF_CHAIN("promote", promote())
-  ELIF_CHAIN("swap", swap(args[1]))
+  ELIF_CHAIN("swapcol", swap(args[1]))
   {
     // note: never forget the default... this took way to long to find..
   }

--- a/hyprscrolling/Scrolling.cpp
+++ b/hyprscrolling/Scrolling.cpp
@@ -97,6 +97,15 @@ SP<SScrollingWindowData> SColumnData::prev(SP<SScrollingWindowData> w) {
 
     return nullptr;
 }
+void SColumnData::swap(SP<SScrollingWindowData> w) {
+  auto it = std::find(windowDatas.begin(), windowDatas.end(), w);
+  if(it != windowDatas.end())
+  {
+    auto i = std::distance(windowDatas.begin(), it);
+    if(i > 0)
+      std::swap(windowDatas[i], windowDatas[i-1]);
+  }
+}
 
 bool SColumnData::has(PHLWINDOW w) {
     return std::ranges::find_if(windowDatas, [w](const auto& e) { return e->window == w; }) != windowDatas.end();
@@ -1033,6 +1042,9 @@ std::any CScrollingLayout::layoutMessage(SLayoutMessageHeader header, std::strin
         WDATA->column->remove(WDATA->window.lock());
 
         col->add(WDATA);
+    } else if (ARGS[0] == "swapleft") {
+      auto w = dataFor(g_pCompositor->m_lastWindow.lock());
+      w->column->swap(w);
     }
 
     return {};

--- a/hyprscrolling/Scrolling.cpp
+++ b/hyprscrolling/Scrolling.cpp
@@ -1162,12 +1162,13 @@ void CScrollingLayout::swap(PHLWINDOW w, const std::string &dir) {
     if(it != wds->columns.end())
     {
       auto i = std::distance(wds->columns.begin(), it);
-      if(i >= 0)
+      if(i >= 0 && i + offset < wds->columns.size())
       {
-        Debug::log(ERR,"i = {} offset = {} size = {}", i,offset,wds->columns.size());
+        // maybe focus the swapped out window? who knows.
+        //g_pCompositor->focusWindow(wds->columns[i+offset]->windowDatas.front()->window.lock());
         std::swap(wds->columns[i], wds->columns[i+offset]);
+        wds->centerCol(wds->columns[i+offset]);
+        wds->recalculate();
       }
-      wds->recalculate();
-      g_pCompositor->focusWindow(wd->window.lock());
   }
 }

--- a/hyprscrolling/Scrolling.hpp
+++ b/hyprscrolling/Scrolling.hpp
@@ -38,7 +38,6 @@ struct SColumnData {
 
     SP<SScrollingWindowData>              next(SP<SScrollingWindowData> w);
     SP<SScrollingWindowData>              prev(SP<SScrollingWindowData> w);
-    void                                  swap(SP<SScrollingWindowData> w);
 
     std::vector<SP<SScrollingWindowData>> windowDatas;
     float                                 columnSize  = 1.F;
@@ -112,6 +111,7 @@ class CScrollingLayout : public IHyprLayout {
     SP<SWorkspaceData>       dataFor(PHLWORKSPACE ws);
     SP<SScrollingWindowData> dataFor(PHLWINDOW w);
     SP<SWorkspaceData>       currentWorkspaceData();
+    void                     swap(PHLWINDOW w, const std::string& dir);
 
     void                     applyNodeDataToWindow(SP<SScrollingWindowData> node, bool force);
 

--- a/hyprscrolling/Scrolling.hpp
+++ b/hyprscrolling/Scrolling.hpp
@@ -38,6 +38,7 @@ struct SColumnData {
 
     SP<SScrollingWindowData>              next(SP<SScrollingWindowData> w);
     SP<SScrollingWindowData>              prev(SP<SScrollingWindowData> w);
+    void                                  swap(SP<SScrollingWindowData> w);
 
     std::vector<SP<SScrollingWindowData>> windowDatas;
     float                                 columnSize  = 1.F;

--- a/hyprscrolling/Scrolling.hpp
+++ b/hyprscrolling/Scrolling.hpp
@@ -103,6 +103,8 @@ class CScrollingLayout : public IHyprLayout {
     void                             move(SP<SWorkspaceData> ws, std::string arg);
     void                             colresize(SP<SWorkspaceData> ws, Hyprutils::String::CVarList args);
     void                             fit(Hyprutils::String::CVarList args);
+    void                             focus(const std::string &arg);
+    void                             promote();
     CBox                             usableAreaFor(PHLMONITOR m);
 
   private:
@@ -121,7 +123,7 @@ class CScrollingLayout : public IHyprLayout {
     SP<SWorkspaceData>       dataFor(PHLWORKSPACE ws);
     SP<SScrollingWindowData> dataFor(PHLWINDOW w);
     SP<SWorkspaceData>       currentWorkspaceData();
-    void                     swap(PHLWINDOW w, const std::string& dir);
+    void                     swap(const std::string& dir);
 
     void                     applyNodeDataToWindow(SP<SScrollingWindowData> node, bool force);
 

--- a/hyprscrolling/Scrolling.hpp
+++ b/hyprscrolling/Scrolling.hpp
@@ -95,22 +95,29 @@ class CScrollingLayout : public IHyprLayout {
     virtual std::string              getLayoutName();
     virtual void                     replaceWindowDataWith(PHLWINDOW from, PHLWINDOW to);
     virtual Vector2D                 predictSizeForNewWindowTiled();
+    virtual void                     moveActiveWindow(const Vector2D&, PHLWINDOW w);
 
     virtual void                     onEnable();
     virtual void                     onDisable();
+    virtual void                     onWindowFocusChange(PHLWINDOW w);
+
+
     void                             loadConfig();
     void                             centerOrFit(const SP<SWorkspaceData> ws, const SP<SColumnData> col);
-    void                             move(SP<SWorkspaceData> ws, std::string arg);
-    void                             colresize(SP<SWorkspaceData> ws, Hyprutils::String::CVarList args);
-    void                             fit(Hyprutils::String::CVarList args);
-    void                             focus(const std::string &arg);
-    void                             promote();
     CBox                             usableAreaFor(PHLMONITOR m);
+
+    SDispatchResult                  move(const std::string &arg);
+    SDispatchResult                  colresize(const std::string &args);
+    SDispatchResult                  fit(const std::string &args);
+    SDispatchResult                  focus(const std::string &arg);
+    SDispatchResult                  promote();
+    SDispatchResult                  swap(const std::string& dir);
 
   private:
     std::vector<SP<SWorkspaceData>> m_workspaceDatas;
 
     SP<HOOK_CALLBACK_FN>            m_configCallback;
+    SP<HOOK_CALLBACK_FN>            m_activewindowCB;
 
     struct {
         float column_width;
@@ -118,12 +125,12 @@ class CScrollingLayout : public IHyprLayout {
         int focus_fit_method;
         bool fullscreen_on_one;
         float special_scale_factor;
+        int center_on_focus;
     } m_config;
 
     SP<SWorkspaceData>       dataFor(PHLWORKSPACE ws);
     SP<SScrollingWindowData> dataFor(PHLWINDOW w);
     SP<SWorkspaceData>       currentWorkspaceData();
-    void                     swap(const std::string& dir);
 
     void                     applyNodeDataToWindow(SP<SScrollingWindowData> node, bool force);
 

--- a/hyprscrolling/Scrolling.hpp
+++ b/hyprscrolling/Scrolling.hpp
@@ -4,6 +4,8 @@
 #include <hyprland/src/layout/IHyprLayout.hpp>
 #include <hyprland/src/helpers/memory/Memory.hpp>
 #include <hyprland/src/managers/HookSystemManager.hpp>
+#include <hyprland/src/config/ConfigValue.hpp>
+#include <hyprutils/string/VarList.hpp>
 
 class CScrollingLayout;
 struct SColumnData;
@@ -96,7 +98,11 @@ class CScrollingLayout : public IHyprLayout {
 
     virtual void                     onEnable();
     virtual void                     onDisable();
-
+    void                             loadConfig();
+    void                             centerOrFit(const SP<SWorkspaceData> ws, const SP<SColumnData> col);
+    void                             move(SP<SWorkspaceData> ws, std::string arg);
+    void                             colresize(SP<SWorkspaceData> ws, Hyprutils::String::CVarList args);
+    void                             fit(Hyprutils::String::CVarList args);
     CBox                             usableAreaFor(PHLMONITOR m);
 
   private:
@@ -105,7 +111,11 @@ class CScrollingLayout : public IHyprLayout {
     SP<HOOK_CALLBACK_FN>            m_configCallback;
 
     struct {
+        float column_width;
         std::vector<float> configuredWidths;
+        int focus_fit_method;
+        bool fullscreen_on_one;
+        float special_scale_factor;
     } m_config;
 
     SP<SWorkspaceData>       dataFor(PHLWORKSPACE ws);

--- a/hyprscrolling/main.cpp
+++ b/hyprscrolling/main.cpp
@@ -47,7 +47,15 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprscrolling:column_width", Hyprlang::FLOAT{0.5F});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprscrolling:focus_fit_method", Hyprlang::INT{0});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprscrolling:explicit_column_widths", Hyprlang::STRING{"0.333, 0.5, 0.667, 1.0"});
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprscrolling:center_on_focus", Hyprlang::INT{0});
     HyprlandAPI::addLayout(PHANDLE, "scrolling", g_pScrollingLayout.get());
+
+    HyprlandAPI::addDispatcherV2(PHANDLE, "move", [](const std::string& args) -> SDispatchResult { return g_pScrollingLayout->move(args); });
+    HyprlandAPI::addDispatcherV2(PHANDLE, "fit", [](const std::string& args) -> SDispatchResult { return g_pScrollingLayout->fit(args); });
+    HyprlandAPI::addDispatcherV2(PHANDLE, "focus", [](const std::string& args) -> SDispatchResult { return g_pScrollingLayout->focus(args); });
+    HyprlandAPI::addDispatcherV2(PHANDLE, "colresize", [](const std::string& args) -> SDispatchResult { return g_pScrollingLayout->colresize(args); });
+    HyprlandAPI::addDispatcherV2(PHANDLE, "swapcol", [](const std::string& args) -> SDispatchResult { return g_pScrollingLayout->swap(args); });
+    HyprlandAPI::addDispatcherV2(PHANDLE, "promote", [](const std::string& args) -> SDispatchResult { return g_pScrollingLayout->promote(); });
 
         if (success) HyprlandAPI::addNotification(PHANDLE, "[hyprscrolling] Initialized successfully!", CHyprColor{0.2, 1.0, 0.2, 1.0}, 5000);
     else {
@@ -60,5 +68,11 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 
 APICALL EXPORT void PLUGIN_EXIT() {
     HyprlandAPI::removeLayout(PHANDLE, g_pScrollingLayout.get());
+    HyprlandAPI::removeDispatcher(PHANDLE, "move");
+    HyprlandAPI::removeDispatcher(PHANDLE, "fit");
+    HyprlandAPI::removeDispatcher(PHANDLE, "focus");
+    HyprlandAPI::removeDispatcher(PHANDLE, "colresize");
+    HyprlandAPI::removeDispatcher(PHANDLE, "swapcol");
+    HyprlandAPI::removeDispatcher(PHANDLE, "promote");
     g_pScrollingLayout.reset();
 }


### PR DESCRIPTION
There was a request to make columns swappable, so added that.
Added center_on_focus to keep the currently focused window in the center at all times, works great without mouse follow, not so great if mouse follow is on..
Moved the stuff in layoutmsg to their own functions so they can be called as dispatchers.
Also added switchWindows because why not.