### PR TITLE
hyprfocus: fix nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,7 @@
         csgo-vulkan-fix
         hyprbars
         hyprexpo
+        hyprfocus
         hyprscrolling
         hyprtrails
         hyprwinwrap
@@ -54,6 +55,7 @@
             csgo-vulkan-fix = callPackage ./csgo-vulkan-fix {};
             hyprbars = callPackage ./hyprbars {};
             hyprexpo = callPackage ./hyprexpo {};
+            hyprfocus = callPackage ./hyprfocus {};
             hyprscrolling = callPackage ./hyprscrolling {};
             hyprtrails = callPackage ./hyprtrails {};
             hyprwinwrap = callPackage ./hyprwinwrap {};

--- a/hyprfocus/meson.build
+++ b/hyprfocus/meson.build
@@ -1,0 +1,30 @@
+project('hyprfocus', 'cpp',
+  version: '0.1',
+  default_options: ['buildtype=release'],
+)
+
+cpp_compiler = meson.get_compiler('cpp')
+if cpp_compiler.has_argument('-std=c++23')
+  add_global_arguments('-std=c++23', language: 'cpp')
+elif cpp_compiler.has_argument('-std=c++2b')
+  add_global_arguments('-std=c++2b', language: 'cpp')
+else
+  error('Could not configure current C++ compiler (' + cpp_compiler.get_id() + ' ' + cpp_compiler.version() + ') with required C++ standard (C++23)')
+endif
+
+globber = run_command('find', '.', '-name', '*.cpp', check: true)
+src = globber.stdout().strip().split('\n')
+
+shared_module(meson.project_name(), src,
+  dependencies: [
+    dependency('hyprland'),
+    dependency('libdrm'),
+    dependency('libinput'),
+    dependency('libudev'),
+    dependency('pangocairo'),
+    dependency('pixman-1'),
+    dependency('wayland-server'),
+    dependency('xkbcommon'),
+  ],
+  install: true,
+)


### PR DESCRIPTION
added meson.build (copied from hyprscrolling, but alphabetized dependencies to match CMakeLists)
also added hyprfocus to flake.nix