### PR TITLE
Updated Hyprbars documentation

### DIFF
--- a/hyprbars/README.md
+++ b/hyprbars/README.md
@@ -2,7 +2,7 @@
 
 Adds simple title bars to windows.
 
-![preview](https://i.ibb.co/hLDRCpT/20231029-22h30m05s.png)
+![image](https://github.com/user-attachments/assets/184a66b9-eb91-4f6f-8953-b265a2735939)
 
 ## Config
 
@@ -25,39 +25,25 @@ plugin {
 }
 ```
 
-`enabled` -> (bool) whether to enable the bars
-
-`bar_color` -> (col) bar's background color
-
-`bar_height` -> (int) bar's height (default `15`)
-
-`bar_blur` -> (bool) whether to blur the bar. Also requires the global blur to be enabled.
-
-`col.text` -> (col) bar's title text color
-
-`bar_title_enabled` -> (bool) whether to render the title (default `true`)
-
-`bar_text_size` -> (int) bar's title text font size (default `10`)
-
-`bar_text_font` -> (str) bar's title text font (default `Sans`)
-
-`bar_text_align` -> (str) bar's title text alignment (default `center`, can also be `left`)
-
-`bar_buttons_alignment` -> (str) bar's buttons alignment (default: `right`, can also be `left`)
-
-`bar_part_of_window` -> (bool) whether the bar is a part of the main window (if it is, stuff like shadows render around it)
-
-`bar_precedence_over_border` -> (bool) whether the bar should have a higher priority than the border (border will be around the bar)
-
-`bar_padding` -> (int) left / right edge padding (default `7`)
-
-`bar_button_padding` -> (int) padding between the buttons (default `5`)
-
-`icon_on_hover` -> (bool) whether the icons show on mouse hovering over the buttons (default `false`)
-
-`inactive_button_color` -> (col) buttons bg color when window isn't focused
-
-`on_double_click` -> (str) command to run on double click of the bar (not on a button)
+| property | type | description | default |
+| --- | --- | --- | --- |
+`enabled` | bool | whether to enable the bars |
+`bar_color` | color | bar's background color
+`bar_height` | int | bar's height | `15`
+`bar_blur` | bool | whether to blur the bar. Also requires the global blur to be enabled.
+`col.text` | color | bar's title text color
+`bar_title_enabled` | bool | whether to render the title | `true`
+`bar_text_size` | int | bar's title text font size | `10`
+`bar_text_font` | str | bar's title text font | `Sans`
+`bar_text_align` | left, center | bar's title text alignment | `center`
+`bar_buttons_alignment` | right, left | bar's buttons alignment | `right`
+`bar_part_of_window` | bool | whether the bar is a part of the main window (if it is, stuff like shadows render around it)
+`bar_precedence_over_border` | bool | whether the bar should have a higher priority than the border (border will be around the bar)
+`bar_padding` | int | left / right edge padding | `7`
+`bar_button_padding` | int | padding between the buttons | `5`
+`icon_on_hover` | bool | whether the icons show on mouse hovering over the buttons | `false`
+`inactive_button_color` | col | buttons bg color when window isn't focused
+`on_double_click` | str | command to run on double click of the bar (not on a button)
 
 ## Buttons Config
 
@@ -69,8 +55,14 @@ hyprbars-button = bgcolor, size, icon, on-click, fgcolor
 
 ## Window rules
 
-Hyprbars supports the following _dynamic_ window rules:
+Hyprbars supports the following _dynamic_ [window rules](https://wiki.hypr.land/Configuring/Window-Rules/):
 
-`plugin:hyprbars:nobar` -> disables the bar on matching windows.
-`plugin:hyprbars:bar_color` -> sets the bar background color on matching windows.
-`plugin:hyprbars:title_color` -> sets the bar title color on matching windows.
+`plugin:hyprbars:nobar` -> disables the bar on matching windows.  
+`plugin:hyprbars:bar_color` -> sets the bar background color on matching windows.  
+`plugin:hyprbars:title_color` -> sets the bar title color on matching windows.  
+
+Example:
+```bash
+# Sets the bar color in red for all windows that have 'myClass' as a class
+windowrule = plugin:hyprbars:bar_color rgb(ff0000), class:^(myClass)
+```


### PR DESCRIPTION
My work here has been to update the Hyprbars documentation, as it may be a bit hard for newcomers to apply, especially the `window rule` part, which lacked examples.

Changes made to the documentation: 
- [X] Changed the preview picture,
- [X] Changed the properties list to a table (easier to read)
- [X] Added a link to the window rules page in Hyprland's official documentation
- [X] Added an example of an actual hyprbars window rule