### PR TITLE
feature(hyprwinwrap): adds option to select window by title

### DIFF
--- a/hyprwinwrap/README.md
+++ b/hyprwinwrap/README.md
@@ -8,6 +8,8 @@ plugin {
     hyprwinwrap {
         # class is an EXACT match and NOT a regex!
         class = kitty-bg
+        # you can also use title
+        title = kitty-bg
     }
 }
 

--- a/hyprwinwrap/main.cpp
+++ b/hyprwinwrap/main.cpp
@@ -34,19 +34,15 @@ std::vector<PHLWINDOWREF> bgWindows;
 
 //
 void onNewWindow(PHLWINDOW pWindow) {
-    // Get the configured class and title from Hyprland's config
     static auto* const PCLASS = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprwinwrap:class")->getDataStaticPtr();
     static auto* const PTITLE = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprwinwrap:title")->getDataStaticPtr();
 
-    // Create C++ strings from the config values for safe handling
     const std::string classRule(*PCLASS);
     const std::string titleRule(*PTITLE);
 
-    // Check if the rule is non-empty and matches the window property
     const bool classMatches = !classRule.empty() && pWindow->m_initialClass == classRule;
     const bool titleMatches = !titleRule.empty() && pWindow->m_title == titleRule;
 
-    // If neither the class nor the title matches, we ignore the window
     if (!classMatches && !titleMatches)
         return;
 
@@ -136,17 +132,15 @@ void onCommit(void* owner, void* data) {
 }
 
 void onConfigReloaded() {
-    // Get the configured class and apply window rules if it's set
     static auto* const PCLASS = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprwinwrap:class")->getDataStaticPtr();
-    const std::string classRule(*PCLASS); // Create a C++ string
+    const std::string classRule(*PCLASS);
     if (!classRule.empty()) {
         g_pConfigManager->parseKeyword("windowrulev2", std::string{"float, class:^("} + classRule + ")$");
         g_pConfigManager->parseKeyword("windowrulev2", std::string{"size 100\% 100\%, class:^("} + classRule + ")$");
     }
 
-    // Get the configured title and apply window rules if it's set
     static auto* const PTITLE = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprwinwrap:title")->getDataStaticPtr();
-    const std::string titleRule(*PTITLE); // Create a C++ string
+    const std::string titleRule(*PTITLE);
     if (!titleRule.empty()) {
         g_pConfigManager->parseKeyword("windowrulev2", std::string{"float, title:^("} + titleRule + ")$");
         g_pConfigManager->parseKeyword("windowrulev2", std::string{"size 100\% 100\%, title:^("} + titleRule + ")$");

--- a/hyprwinwrap/main.cpp
+++ b/hyprwinwrap/main.cpp
@@ -34,9 +34,20 @@ std::vector<PHLWINDOWREF> bgWindows;
 
 //
 void onNewWindow(PHLWINDOW pWindow) {
+    // Get the configured class and title from Hyprland's config
     static auto* const PCLASS = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprwinwrap:class")->getDataStaticPtr();
+    static auto* const PTITLE = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprwinwrap:title")->getDataStaticPtr();
 
-    if (pWindow->m_initialClass != *PCLASS)
+    // Create C++ strings from the config values for safe handling
+    const std::string classRule(*PCLASS);
+    const std::string titleRule(*PTITLE);
+
+    // Check if the rule is non-empty and matches the window property
+    const bool classMatches = !classRule.empty() && pWindow->m_initialClass == classRule;
+    const bool titleMatches = !titleRule.empty() && pWindow->m_title == titleRule;
+
+    // If neither the class nor the title matches, we ignore the window
+    if (!classMatches && !titleMatches)
         return;
 
     const auto PMONITOR = pWindow->m_monitor.lock();
@@ -49,9 +60,9 @@ void onNewWindow(PHLWINDOW pWindow) {
 
     pWindow->m_realSize->setValueAndWarp(PMONITOR->m_size);
     pWindow->m_realPosition->setValueAndWarp(PMONITOR->m_position);
-    pWindow->m_size     = PMONITOR->m_size;
-    pWindow->m_position = PMONITOR->m_position;
-    pWindow->m_pinned   = true;
+    pWindow->m_size      = PMONITOR->m_size;
+    pWindow->m_position  = PMONITOR->m_position;
+    pWindow->m_pinned    = true;
     pWindow->sendWindowSize(true);
 
     bgWindows.push_back(pWindow);
@@ -125,9 +136,21 @@ void onCommit(void* owner, void* data) {
 }
 
 void onConfigReloaded() {
+    // Get the configured class and apply window rules if it's set
     static auto* const PCLASS = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprwinwrap:class")->getDataStaticPtr();
-    g_pConfigManager->parseKeyword("windowrulev2", std::string{"float, class:^("} + *PCLASS + ")$");
-    g_pConfigManager->parseKeyword("windowrulev2", std::string{"size 100\% 100\%, class:^("} + *PCLASS + ")$");
+    const std::string classRule(*PCLASS); // Create a C++ string
+    if (!classRule.empty()) {
+        g_pConfigManager->parseKeyword("windowrulev2", std::string{"float, class:^("} + classRule + ")$");
+        g_pConfigManager->parseKeyword("windowrulev2", std::string{"size 100\% 100\%, class:^("} + classRule + ")$");
+    }
+
+    // Get the configured title and apply window rules if it's set
+    static auto* const PTITLE = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprwinwrap:title")->getDataStaticPtr();
+    const std::string titleRule(*PTITLE); // Create a C++ string
+    if (!titleRule.empty()) {
+        g_pConfigManager->parseKeyword("windowrulev2", std::string{"float, title:^("} + titleRule + ")$");
+        g_pConfigManager->parseKeyword("windowrulev2", std::string{"size 100\% 100\%, title:^("} + titleRule + ")$");
+    }
 }
 
 APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
@@ -169,7 +192,8 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
         throw std::runtime_error("hyprwinwrap: hooks failed");
 
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprwinwrap:class", Hyprlang::STRING{"kitty-bg"});
-
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprwinwrap:title", Hyprlang::STRING{""});
+    
     HyprlandAPI::addNotification(PHANDLE, "[hyprwinwrap] Initialized successfully!", CHyprColor{0.2, 1.0, 0.2, 1.0}, 5000);
 
     return {"hyprwinwrap", "A clone of xwinwrap for Hyprland", "Vaxry", "1.0"};
@@ -178,3 +202,4 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 APICALL EXPORT void PLUGIN_EXIT() {
     ;
 }
+


### PR DESCRIPTION
Hi there!

The goal of this PR is to enhance `hyprwinwrap` by adding the ability to select a window by its title, in addition to the existing method of selecting by its class.

It closes #271 

### Motivation

Some applications (or specific instances of applications) may not have a unique class but can be identified by their window title. This change provides more flexibility for users to wrap the exact windows they want.

### Changes Implemented

- Added a new configuration option: `plugin:hyprwinwrap:title`
- Updated `onNewWindow()` to check for a match on either class or title.
- Updated `onConfigReloaded()` to apply the necessary `windowrulev2` rules for titles.