### PR TITLE
hyprbars: use the setcap to cache glenable/disable

### DIFF
--- a/hyprbars/barDeco.cpp
+++ b/hyprbars/barDeco.cpp
@@ -94,8 +94,8 @@ bool CHyprBar::inputIsValid() {
         return false;
 
     // check if input is on top or overlay shell layers
-    auto PMONITOR                  = g_pCompositor->m_lastMonitor.lock();
-    PHLLS foundSurface             = nullptr;
+    auto     PMONITOR     = g_pCompositor->m_lastMonitor.lock();
+    PHLLS    foundSurface = nullptr;
     Vector2D surfaceCoords;
 
     // check top layer
@@ -104,7 +104,8 @@ bool CHyprBar::inputIsValid() {
     if (foundSurface)
         return false;
     // check overlay layer
-    g_pCompositor->vectorToLayerSurface(g_pInputManager->getMouseCoordsInternal(), &PMONITOR->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY], &surfaceCoords, &foundSurface);
+    g_pCompositor->vectorToLayerSurface(g_pInputManager->getMouseCoordsInternal(), &PMONITOR->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY], &surfaceCoords,
+                                        &foundSurface);
 
     if (foundSurface)
         return false;
@@ -449,8 +450,8 @@ void CHyprBar::renderBarButtons(const Vector2D& bufferSize, const float scale) {
         const auto  scaledButtonSize = button.size * scale;
         const auto  scaledButtonsPad = **PBARBUTTONPADDING * scale;
 
-        const auto  pos = Vector2D{BUTTONSRIGHT ? bufferSize.x - offset - scaledButtonSize / 2.0 : offset + scaledButtonSize / 2.0, bufferSize.y / 2.0}.floor();
-        auto      color = button.bgcol;
+        const auto  pos   = Vector2D{BUTTONSRIGHT ? bufferSize.x - offset - scaledButtonSize / 2.0 : offset + scaledButtonSize / 2.0, bufferSize.y / 2.0}.floor();
+        auto        color = button.bgcol;
 
         if (**PINACTIVECOLOR > 0) {
             color = m_bWindowHasFocus ? color : CHyprColor(**PINACTIVECOLOR);
@@ -572,11 +573,11 @@ void CHyprBar::renderPass(PHLMONITOR pMonitor, const float& a) {
         bool currentWindowFocus = PWINDOW == g_pCompositor->m_lastWindow.lock();
         if (currentWindowFocus != m_bWindowHasFocus) {
             m_bWindowHasFocus = currentWindowFocus;
-            m_bButtonsDirty = true;
+            m_bButtonsDirty   = true;
         }
     }
 
-    const CHyprColor   DEST_COLOR = m_bForcedBarColor.value_or(**PCOLOR);
+    const CHyprColor DEST_COLOR = m_bForcedBarColor.value_or(**PCOLOR);
     if (DEST_COLOR != m_cRealBarColor->goal())
         *m_cRealBarColor = DEST_COLOR;
 
@@ -626,7 +627,7 @@ void CHyprBar::renderPass(PHLMONITOR pMonitor, const float& a) {
         glClearStencil(0);
         glClear(GL_STENCIL_BUFFER_BIT);
 
-        glEnable(GL_STENCIL_TEST);
+        g_pHyprOpenGL->setCapStatus(GL_STENCIL_TEST, true);
 
         glStencilFunc(GL_ALWAYS, 1, -1);
         glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
@@ -656,7 +657,7 @@ void CHyprBar::renderPass(PHLMONITOR pMonitor, const float& a) {
         // cleanup stencil
         glClearStencil(0);
         glClear(GL_STENCIL_BUFFER_BIT);
-        glDisable(GL_STENCIL_TEST);
+        g_pHyprOpenGL->setCapStatus(GL_STENCIL_TEST, false);
         glStencilMask(-1);
         glStencilFunc(GL_ALWAYS, 1, 0xFF);
     }


### PR DESCRIPTION
use the compositor cache setcap function to make the gl state mismatch with our cpu cached values.

fixes: https://github.com/hyprwm/hyprland-plugins/issues/408