### PR TITLE
hyprexpo: Implement `skip_empty` config option for alternative empty workspace behavior

### DIFF
--- a/hyprexpo/README.md
+++ b/hyprexpo/README.md
@@ -30,6 +30,7 @@ columns | number | how many desktops are displayed on one line | `3`
 gap_size | number | gap between desktops | `5`
 bg_col | color | color in gaps (between desktops) | `rgb(000000)`
 workspace_method | [center/first] [workspace] | position of the desktops | `center current`
+skip_empty | boolean | whether the grid displays workspaces sequentially by id using selector "r" (`false`) or skips empty workspaces using selector "m" (`true`) | `false`
 enable_gesture | boolean | enable touchpad gestures | `true`
 gesture_fingers | `3` or `4` | how many fingers are needed in the gesture | `3`
 gesture_distance | number | how far is the max | `300`

--- a/hyprexpo/main.cpp
+++ b/hyprexpo/main.cpp
@@ -225,6 +225,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:gap_size", Hyprlang::INT{5});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:bg_col", Hyprlang::INT{0xFF111111});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:workspace_method", Hyprlang::STRING{"center current"});
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:skip_empty", Hyprlang::INT{0});
 
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:enable_gesture", Hyprlang::INT{1});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprexpo:gesture_distance", Hyprlang::INT{200});


### PR DESCRIPTION
Currently, this plugin uses the workspace selector `r` when filling the overview grid. This may be fine, but if you quickly activate the overview and select an "empty square", you can find yourself in the middle of a sea of empty workspaces to the point that the one you came from is too far to even be displayed on the grid.

This PR implements a config option `skip_empty` that tweaks the behavior as to use the workspace selector `m` to fill the grid. To avoid wrapping, subsequent workspaces are left with an id of `WORKSPACE_INVALID`, and upon clicking one, you are taken to the workspace selected by `emptynm` (next empty workspace on monitor).

Overall, this results in the overview grid only being populated by your non-empty workspaces, arranged sequentially. Selecting any  "empty" workspace results in the next new empty workspace.

Documentation has been added, and code formatted.