### PR TITLE
Hyprscrolling: Make resizeactive keyboard binds work for vertical window resizing

### DIFF
--- a/hyprscrolling/Scrolling.cpp
+++ b/hyprscrolling/Scrolling.cpp
@@ -612,7 +612,7 @@ void CScrollingLayout::onBeginDragWindow() {
 
 void CScrollingLayout::resizeActiveWindow(const Vector2D& delta, eRectCorner corner, PHLWINDOW pWindow) {
     const auto PWINDOW = pWindow ? pWindow : g_pCompositor->m_lastWindow.lock();
-    Vector2D   mod_delta = delta;
+    Vector2D   modDelta = delta;
 
     if (!validMapped(PWINDOW))
         return;
@@ -665,11 +665,11 @@ void CScrollingLayout::resizeActiveWindow(const Vector2D& delta, eRectCorner cor
         const auto NEXT_WD = DATA->column->next(DATA);
         const auto PREV_WD = DATA->column->prev(DATA);
         if (corner == CORNER_NONE) {
-            if (!PREV_WD) {
+            if (!PREV_WD)
                 corner = CORNER_BOTTOMRIGHT;
-            } else {
+            else {
                 corner = CORNER_TOPRIGHT;
-                mod_delta.y *= -1.0f;
+                modDelta.y *= -1.0f;
             }
         }
 
@@ -693,10 +693,10 @@ void CScrollingLayout::resizeActiveWindow(const Vector2D& delta, eRectCorner cor
                 if (!PREV_WD)
                     break;
 
-                if (PREV_WD->windowSize <= MIN_ROW_HEIGHT && mod_delta.y <= 0 || CURR_WD->windowSize <= MIN_ROW_HEIGHT && delta.y >= 0)
+                if (PREV_WD->windowSize <= MIN_ROW_HEIGHT && modDelta.y <= 0 || CURR_WD->windowSize <= MIN_ROW_HEIGHT && delta.y >= 0)
                     break;
 
-                float adjust = std::clamp((float)(mod_delta.y / USABLE.h), -(PREV_WD->windowSize - MIN_ROW_HEIGHT), (CURR_WD->windowSize - MIN_ROW_HEIGHT));
+                float adjust = std::clamp((float)(modDelta.y / USABLE.h), -(PREV_WD->windowSize - MIN_ROW_HEIGHT), (CURR_WD->windowSize - MIN_ROW_HEIGHT));
 
                 PREV_WD->windowSize = std::clamp(PREV_WD->windowSize + adjust, MIN_ROW_HEIGHT, MAX_ROW_HEIGHT);
                 CURR_WD->windowSize = std::clamp(CURR_WD->windowSize - adjust, MIN_ROW_HEIGHT, MAX_ROW_HEIGHT);


### PR DESCRIPTION
Set a corner to resize from.
Negate delta.y when resizing not-top window in the column. Seems to also fix using exact when resizing not-top window.