### PR TITLE
Hyprscrolling: centerOrFit with 'focus' when first or last column already focused.

### DIFF
--- a/hyprscrolling/Scrolling.cpp
+++ b/hyprscrolling/Scrolling.cpp
@@ -1082,9 +1082,11 @@ std::any CScrollingLayout::layoutMessage(SLayoutMessageHeader header, std::strin
             case 'l': {
                 auto PREV = WDATA->column->workspace->prev(WDATA->column.lock());
                 if (!PREV) {
-                    if (*PNOFALLBACK)
+                    if (*PNOFALLBACK) {
+                        centerOrFit(WDATA->column->workspace.lock(), WDATA->column.lock());
+                        WDATA->column->workspace->recalculate();
                         break;
-                    else
+                    } else
                         PREV = WDATA->column->workspace->columns.back();
                 }
 
@@ -1097,9 +1099,11 @@ std::any CScrollingLayout::layoutMessage(SLayoutMessageHeader header, std::strin
             case 'r': {
                 auto NEXT = WDATA->column->workspace->next(WDATA->column.lock());
                 if (!NEXT) {
-                    if (*PNOFALLBACK)
+                    if (*PNOFALLBACK) {
+                        centerOrFit(WDATA->column->workspace.lock(), WDATA->column.lock());
+                        WDATA->column->workspace->recalculate();
                         break;
-                    else
+                    } else
                         NEXT = WDATA->column->workspace->columns.front();
                 }
 


### PR DESCRIPTION
When using `no_focus_fallback`, a window in the last column focused but not (entirely) visible, using `layoutmsg focus right` does nothing. To bring the column in to view, you have to focus left, then `layoutmsg focus right` or use a 

This change makes `layoutmsg focus left,right` centerOrFit the column when the first or last column is active.