### PR TITLE
hyprscrolling: SColumnData::down break after window swap

### DIFF
--- a/hyprscrolling/Scrolling.cpp
+++ b/hyprscrolling/Scrolling.cpp
@@ -99,6 +99,7 @@ void SColumnData::up(SP<SScrollingWindowData> w) {
             continue;
 
         std::swap(windowDatas[i], windowDatas[i - 1]);
+        break;
     }
 }
 
@@ -108,6 +109,7 @@ void SColumnData::down(SP<SScrollingWindowData> w) {
             continue;
 
         std::swap(windowDatas[i], windowDatas[i + 1]);
+        break;
     }
 }
 


### PR DESCRIPTION
SColumnData::down iterates over windowDatas till it matches the target window then swaps it with windowDatas[i + 1], becoming the next window in windowDatas so it matches every subsequent iteration till it's the last window in the column.

So break out after the swap().

Fixes https://github.com/hyprwm/hyprland-plugins/issues/452