### PR TITLE
hyprscrolling: fix(fullscreen) Ensure maximized state is restored from full-screen

### DIFF
--- a/hyprscrolling/Scrolling.cpp
+++ b/hyprscrolling/Scrolling.cpp
@@ -378,7 +378,7 @@ void CScrollingLayout::applyNodeDataToWindow(SP<SScrollingWindowData> data, bool
         return;
     }
 
-    if (PWINDOW->isFullscreen())
+    if (PWINDOW->isFullscreen() && !data->ignoreFullscreenChecks)
         return;
 
     PWINDOW->unsetWindowData(PRIORITY_LAYOUT);


### PR DESCRIPTION
This PR fixes a bug where transitioning a window from full-screen mode (mode 2) back to maximized mode (mode 1) would not resize the window correctly, causing it to remain at its full-screen dimensions.

## The Problem

Currently, the sequence of commands leads to unexpected behavior:
1.  Take a tiled window.
2.  Execute `hyprctl dispatch fullscreen 1`. The window becomes maximized (correct).
3.  Execute `hyprctl dispatch fullscreen 2`. The window becomes full-screen (correct).
4.  Execute `hyprctl dispatch fullscreen 1` again.

-   **Expected Behavior:** The window should return to the maximized dimensions, filling the usable monitor area.
-   **Actual Behavior:** The window's dimensions remain unchanged from the full-screen state.

## Root Cause

The root cause is an early return in the `applyNodeDataToWindow` function. The function checks `if (PWINDOW->isFullscreen())` and exits immediately. When transitioning from mode 2 to 1, the window is still considered "fullscreen" at the time of the check, causing the function to bail before applying the new maximized geometry.

The `fullscreenRequestForWindow` function correctly anticipates this by setting an `ignoreFullscreenChecks` flag on a temporary node, but this flag was not being used in the check.

## The Fix

This PR modifies the condition in `applyNodeDataToWindow` to respect the `ignoreFullscreenChecks` flag.

This small change ensures that the layout logic proceeds to apply the new window geometry during a fullscreen state transition, making the behavior consistent and predictable.