### PR TITLE
Hyprscrolling: feat: Add column movement commands (`swapcol`, `movecoltoworkspace`)

### DIFF
--- a/hyprscrolling/README.md
+++ b/hyprscrolling/README.md
@@ -30,3 +30,4 @@ Make sure to set the `general:layout` to `scrolling` to use this layout.
 | focus | moves the focus and centers the layout, while also wrapping instead of moving to neighbring monitors. | direction |
 | promote | moves a window to its own new column | none |
 | swapcol | Swaps the current column with its neighbor to the left (`l`) or right (`r`). The swap wraps around (e.g., swapping the first column left moves it to the end). | `l` or `r` |
+| movecoltoworkspace | Moves the entire current column to the specified workspace, preserving its internal layout. Works with existing, new, and special workspaces. e.g. like `1`, `2`, `-1`, `+2`, `special`, etc. | workspace identifier|

--- a/hyprscrolling/README.md
+++ b/hyprscrolling/README.md
@@ -29,3 +29,4 @@ Make sure to set the `general:layout` to `scrolling` to use this layout.
 | fit | executes a fit operation based on the argument. Available: `active`, `visible`, `all`, `toend`, `tobeg` | fit mode |
 | focus | moves the focus and centers the layout, while also wrapping instead of moving to neighbring monitors. | direction |
 | promote | moves a window to its own new column | none |
+| swapcol | Swaps the current column with its neighbor to the left (`l`) or right (`r`). The swap wraps around (e.g., swapping the first column left moves it to the end). | `l` or `r` |

--- a/hyprscrolling/Scrolling.cpp
+++ b/hyprscrolling/Scrolling.cpp
@@ -1178,14 +1178,12 @@ std::any CScrollingLayout::layoutMessage(SLayoutMessageHeader header, std::strin
         const std::string& direction  = ARGS[1];
         int64_t            target_idx = -1;
 
-        if (direction == "l") {
+        if (direction == "l")
             target_idx = (current_idx == 0) ? (col_count - 1) : (current_idx - 1);
-        } else if (direction == "r") {
+        else if (direction == "r")
             target_idx = (current_idx == (int64_t)col_count - 1) ? 0 : (current_idx + 1);
-        } else {
-            // invalid direction
+        else
             return {};
-        }
 
         std::swap(WS_DATA->columns[current_idx], WS_DATA->columns[target_idx]);
         WS_DATA->centerOrFitCol(CURRENT_COL);
@@ -1262,11 +1260,15 @@ std::any CScrollingLayout::layoutMessage(SLayoutMessageHeader header, std::strin
         NEW_COL->windowDatas = CURRENT_COL->windowDatas;
 
         for (const auto& wd : NEW_COL->windowDatas)
+        {
             wd->column = NEW_COL;
+        }
 
         std::vector<PHLWINDOW> windowsToMove;
         for (const auto& wd : CURRENT_COL->windowDatas)
+        {
             windowsToMove.push_back(wd->window.lock());
+        }
 
         CURRENT_COL->windowDatas.clear();
         SOURCE_WS_DATA->remove(CURRENT_COL);
@@ -1276,14 +1278,18 @@ std::any CScrollingLayout::layoutMessage(SLayoutMessageHeader header, std::strin
             m_columnMoveState.targetWorkspaceID = -1;
 
             for (auto& ws : m_workspaceDatas)
+            {
                 ws->recalculate();
+            }
         });
 
         m_columnMoveState.isMovingColumn    = true;
         m_columnMoveState.targetWorkspaceID = PWORKSPACE->m_id;
 
         for (const auto& win : windowsToMove)
+        {
             g_pCompositor->moveWindowToWorkspaceSafe(win, PWORKSPACE);
+        }
 
         g_pCompositor->focusWindow(windowsToMove.front());
         g_pCompositor->warpCursorTo(windowsToMove.front()->middle());

--- a/hyprscrolling/Scrolling.cpp
+++ b/hyprscrolling/Scrolling.cpp
@@ -1150,6 +1150,45 @@ std::any CScrollingLayout::layoutMessage(SLayoutMessageHeader header, std::strin
         col->add(WDATA);
 
         WDATA->column->workspace->recalculate();
+    } else if (ARGS[0] == "swapcol") {
+        if (ARGS.size() < 2) {
+            return {};
+        }
+
+        const auto WDATA = dataFor(g_pCompositor->m_lastWindow.lock());
+        if (!WDATA)
+            return {};
+
+        const auto CURRENT_COL = WDATA->column.lock();
+        if (!CURRENT_COL)
+            return {};
+
+        const auto WS_DATA = CURRENT_COL->workspace.lock();
+        if (!WS_DATA || WS_DATA->columns.size() < 2) {
+            return {};
+        }
+
+        const int64_t current_idx = WS_DATA->idx(CURRENT_COL);
+        const size_t  col_count   = WS_DATA->columns.size();
+
+        if (current_idx == -1)
+            return {};
+
+        const std::string& direction  = ARGS[1];
+        int64_t            target_idx = -1;
+
+        if (direction == "l") {
+            target_idx = (current_idx == 0) ? (col_count - 1) : (current_idx - 1);
+        } else if (direction == "r") {
+            target_idx = (current_idx == (int64_t)col_count - 1) ? 0 : (current_idx + 1);
+        } else {
+            // invalid direction
+            return {};
+        }
+
+        std::swap(WS_DATA->columns[current_idx], WS_DATA->columns[target_idx]);
+        WS_DATA->centerOrFitCol(CURRENT_COL);
+        WS_DATA->recalculate();
     }
 
     return {};

--- a/hyprscrolling/Scrolling.cpp
+++ b/hyprscrolling/Scrolling.cpp
@@ -519,9 +519,8 @@ void CScrollingLayout::onDisable() {
 }
 
 void CScrollingLayout::onWindowCreatedTiling(PHLWINDOW window, eDirection direction) {
-    if (m_columnMoveState.isMovingColumn && window->m_workspace->m_id == m_columnMoveState.targetWorkspaceID) {
+    if (m_columnMoveState.isMovingColumn && window->m_workspace->m_id == m_columnMoveState.targetWorkspaceID)
         return;
-    }
 
     auto workspaceData = dataFor(window->m_workspace);
 
@@ -1155,9 +1154,8 @@ std::any CScrollingLayout::layoutMessage(SLayoutMessageHeader header, std::strin
 
         WDATA->column->workspace->recalculate();
     } else if (ARGS[0] == "swapcol") {
-        if (ARGS.size() < 2) {
+        if (ARGS.size() < 2)
             return {};
-        }
 
         const auto WDATA = dataFor(g_pCompositor->m_lastWindow.lock());
         if (!WDATA)
@@ -1168,9 +1166,8 @@ std::any CScrollingLayout::layoutMessage(SLayoutMessageHeader header, std::strin
             return {};
 
         const auto WS_DATA = CURRENT_COL->workspace.lock();
-        if (!WS_DATA || WS_DATA->columns.size() < 2) {
+        if (!WS_DATA || WS_DATA->columns.size() < 2)
             return {};
-        }
 
         const int64_t current_idx = WS_DATA->idx(CURRENT_COL);
         const size_t  col_count   = WS_DATA->columns.size();
@@ -1210,9 +1207,8 @@ std::any CScrollingLayout::layoutMessage(SLayoutMessageHeader header, std::strin
             return {};
 
         const auto PMONITOR = g_pCompositor->m_lastWindow->m_monitor.lock();
-        if (!PMONITOR) {
+        if (!PMONITOR)
             return {};
-        }
 
         PHLWORKSPACE       PWORKSPACE = nullptr;
         const std::string& arg        = ARGS[1];
@@ -1223,38 +1219,34 @@ std::any CScrollingLayout::layoutMessage(SLayoutMessageHeader header, std::strin
                 const int currentWorkspaceID = WDATA->window->m_workspace->m_id;
                 const int targetWorkspaceID  = currentWorkspaceID + offset;
 
-                if (targetWorkspaceID < 1) {
+                if (targetWorkspaceID < 1)
                     return {};
-                }
 
                 PWORKSPACE = g_pCompositor->getWorkspaceByID(targetWorkspaceID);
-                if (!PWORKSPACE) {
+                if (!PWORKSPACE)
                     PWORKSPACE = g_pCompositor->createNewWorkspace(targetWorkspaceID, PMONITOR->m_id);
-                }
             } catch (...) { return {}; }
         } else if (arg == "special") {
             const int SPECIAL_WORKSPACE_ID = -99;
             PWORKSPACE                     = g_pCompositor->getWorkspaceByID(SPECIAL_WORKSPACE_ID);
-            if (!PWORKSPACE) {
+            if (!PWORKSPACE)
                 PWORKSPACE = g_pCompositor->createNewWorkspace(SPECIAL_WORKSPACE_ID, PMONITOR->m_id, "special");
-            }
         } else {
             PWORKSPACE = g_pCompositor->getWorkspaceByString(arg);
             if (!PWORKSPACE) {
                 try {
                     const int workspaceID = std::stoi(arg);
                     PWORKSPACE            = g_pCompositor->getWorkspaceByID(workspaceID);
-                    if (!PWORKSPACE) {
+                    if (!PWORKSPACE)
                         PWORKSPACE = g_pCompositor->createNewWorkspace(workspaceID, PMONITOR->m_id);
-                    }
                 } catch (const std::invalid_argument&) { PWORKSPACE = g_pCompositor->createNewWorkspace(0, PMONITOR->m_id, arg); } catch (const std::out_of_range&) {
                     return {};
                 }
             }
         }
-        if (!PWORKSPACE) {
+        if (!PWORKSPACE)
             return {};
-        }
+
         if (PWORKSPACE == WDATA->window->m_workspace)
             return {};
 
@@ -1269,14 +1261,13 @@ std::any CScrollingLayout::layoutMessage(SLayoutMessageHeader header, std::strin
         NEW_COL->columnWidth = CURRENT_COL->columnWidth;
         NEW_COL->windowDatas = CURRENT_COL->windowDatas;
 
-        for (const auto& wd : NEW_COL->windowDatas) {
+        for (const auto& wd : NEW_COL->windowDatas)
             wd->column = NEW_COL;
-        }
 
         std::vector<PHLWINDOW> windowsToMove;
-        for (const auto& wd : CURRENT_COL->windowDatas) {
+        for (const auto& wd : CURRENT_COL->windowDatas)
             windowsToMove.push_back(wd->window.lock());
-        }
+
         CURRENT_COL->windowDatas.clear();
         SOURCE_WS_DATA->remove(CURRENT_COL);
 
@@ -1284,17 +1275,15 @@ std::any CScrollingLayout::layoutMessage(SLayoutMessageHeader header, std::strin
             m_columnMoveState.isMovingColumn    = false;
             m_columnMoveState.targetWorkspaceID = -1;
 
-            for (auto& ws : m_workspaceDatas) {
+            for (auto& ws : m_workspaceDatas)
                 ws->recalculate();
-            }
         });
 
         m_columnMoveState.isMovingColumn    = true;
         m_columnMoveState.targetWorkspaceID = PWORKSPACE->m_id;
 
-        for (const auto& win : windowsToMove) {
+        for (const auto& win : windowsToMove)
             g_pCompositor->moveWindowToWorkspaceSafe(win, PWORKSPACE);
-        }
 
         g_pCompositor->focusWindow(windowsToMove.front());
         g_pCompositor->warpCursorTo(windowsToMove.front()->middle());

--- a/hyprscrolling/Scrolling.cpp
+++ b/hyprscrolling/Scrolling.cpp
@@ -1259,14 +1259,12 @@ std::any CScrollingLayout::layoutMessage(SLayoutMessageHeader header, std::strin
         NEW_COL->columnWidth = CURRENT_COL->columnWidth;
         NEW_COL->windowDatas = CURRENT_COL->windowDatas;
 
-        for (const auto& wd : NEW_COL->windowDatas)
-        {
+        for (const auto& wd : NEW_COL->windowDatas) {
             wd->column = NEW_COL;
         }
 
         std::vector<PHLWINDOW> windowsToMove;
-        for (const auto& wd : CURRENT_COL->windowDatas)
-        {
+        for (const auto& wd : CURRENT_COL->windowDatas) {
             windowsToMove.push_back(wd->window.lock());
         }
 
@@ -1277,8 +1275,7 @@ std::any CScrollingLayout::layoutMessage(SLayoutMessageHeader header, std::strin
             m_columnMoveState.isMovingColumn    = false;
             m_columnMoveState.targetWorkspaceID = -1;
 
-            for (auto& ws : m_workspaceDatas)
-            {
+            for (auto& ws : m_workspaceDatas) {
                 ws->recalculate();
             }
         });
@@ -1286,8 +1283,7 @@ std::any CScrollingLayout::layoutMessage(SLayoutMessageHeader header, std::strin
         m_columnMoveState.isMovingColumn    = true;
         m_columnMoveState.targetWorkspaceID = PWORKSPACE->m_id;
 
-        for (const auto& win : windowsToMove)
-        {
+        for (const auto& win : windowsToMove) {
             g_pCompositor->moveWindowToWorkspaceSafe(win, PWORKSPACE);
         }
 

--- a/hyprscrolling/Scrolling.cpp
+++ b/hyprscrolling/Scrolling.cpp
@@ -519,6 +519,10 @@ void CScrollingLayout::onDisable() {
 }
 
 void CScrollingLayout::onWindowCreatedTiling(PHLWINDOW window, eDirection direction) {
+    if (m_columnMoveState.isMovingColumn && window->m_workspace->m_id == m_columnMoveState.targetWorkspaceID) {
+        return;
+    }
+
     auto workspaceData = dataFor(window->m_workspace);
 
     if (!workspaceData) {
@@ -623,7 +627,7 @@ void CScrollingLayout::onBeginDragWindow() {
 }
 
 void CScrollingLayout::resizeActiveWindow(const Vector2D& delta, eRectCorner corner, PHLWINDOW pWindow) {
-    const auto PWINDOW = pWindow ? pWindow : g_pCompositor->m_lastWindow.lock();
+    const auto PWINDOW  = pWindow ? pWindow : g_pCompositor->m_lastWindow.lock();
     Vector2D   modDelta = delta;
 
     if (!validMapped(PWINDOW))
@@ -1189,8 +1193,112 @@ std::any CScrollingLayout::layoutMessage(SLayoutMessageHeader header, std::strin
         std::swap(WS_DATA->columns[current_idx], WS_DATA->columns[target_idx]);
         WS_DATA->centerOrFitCol(CURRENT_COL);
         WS_DATA->recalculate();
-    }
+    } else if (ARGS[0] == "movecoltoworkspace") {
+        if (ARGS.size() < 2)
+            return {};
 
+        const auto WDATA = dataFor(g_pCompositor->m_lastWindow.lock());
+        if (!WDATA)
+            return {};
+
+        const auto CURRENT_COL = WDATA->column.lock();
+        if (!CURRENT_COL)
+            return {};
+
+        const auto SOURCE_WS_DATA = CURRENT_COL->workspace.lock();
+        if (!SOURCE_WS_DATA)
+            return {};
+
+        const auto PMONITOR = g_pCompositor->m_lastWindow->m_monitor.lock();
+        if (!PMONITOR) {
+            return {};
+        }
+
+        PHLWORKSPACE       PWORKSPACE = nullptr;
+        const std::string& arg        = ARGS[1];
+
+        if (arg.starts_with("+") || arg.starts_with("-")) {
+            try {
+                const int offset             = std::stoi(arg);
+                const int currentWorkspaceID = WDATA->window->m_workspace->m_id;
+                const int targetWorkspaceID  = currentWorkspaceID + offset;
+
+                if (targetWorkspaceID < 1) {
+                    return {};
+                }
+
+                PWORKSPACE = g_pCompositor->getWorkspaceByID(targetWorkspaceID);
+                if (!PWORKSPACE) {
+                    PWORKSPACE = g_pCompositor->createNewWorkspace(targetWorkspaceID, PMONITOR->m_id);
+                }
+            } catch (...) { return {}; }
+        } else if (arg == "special") {
+            const int SPECIAL_WORKSPACE_ID = -99;
+            PWORKSPACE                     = g_pCompositor->getWorkspaceByID(SPECIAL_WORKSPACE_ID);
+            if (!PWORKSPACE) {
+                PWORKSPACE = g_pCompositor->createNewWorkspace(SPECIAL_WORKSPACE_ID, PMONITOR->m_id, "special");
+            }
+        } else {
+            PWORKSPACE = g_pCompositor->getWorkspaceByString(arg);
+            if (!PWORKSPACE) {
+                try {
+                    const int workspaceID = std::stoi(arg);
+                    PWORKSPACE            = g_pCompositor->getWorkspaceByID(workspaceID);
+                    if (!PWORKSPACE) {
+                        PWORKSPACE = g_pCompositor->createNewWorkspace(workspaceID, PMONITOR->m_id);
+                    }
+                } catch (const std::invalid_argument&) { PWORKSPACE = g_pCompositor->createNewWorkspace(0, PMONITOR->m_id, arg); } catch (const std::out_of_range&) {
+                    return {};
+                }
+            }
+        }
+        if (!PWORKSPACE) {
+            return {};
+        }
+        if (PWORKSPACE == WDATA->window->m_workspace)
+            return {};
+
+        auto targetWorkspaceData = dataFor(PWORKSPACE);
+        if (!targetWorkspaceData) {
+            targetWorkspaceData       = m_workspaceDatas.emplace_back(makeShared<SWorkspaceData>(PWORKSPACE, this));
+            targetWorkspaceData->self = targetWorkspaceData;
+        }
+
+        const auto NEW_COL = targetWorkspaceData->add();
+
+        NEW_COL->columnWidth = CURRENT_COL->columnWidth;
+        NEW_COL->windowDatas = CURRENT_COL->windowDatas;
+
+        for (const auto& wd : NEW_COL->windowDatas) {
+            wd->column = NEW_COL;
+        }
+
+        std::vector<PHLWINDOW> windowsToMove;
+        for (const auto& wd : CURRENT_COL->windowDatas) {
+            windowsToMove.push_back(wd->window.lock());
+        }
+        CURRENT_COL->windowDatas.clear();
+        SOURCE_WS_DATA->remove(CURRENT_COL);
+
+        CScopeGuard sg([this]() {
+            m_columnMoveState.isMovingColumn    = false;
+            m_columnMoveState.targetWorkspaceID = -1;
+
+            for (auto& ws : m_workspaceDatas) {
+                ws->recalculate();
+            }
+        });
+
+        m_columnMoveState.isMovingColumn    = true;
+        m_columnMoveState.targetWorkspaceID = PWORKSPACE->m_id;
+
+        for (const auto& win : windowsToMove) {
+            g_pCompositor->moveWindowToWorkspaceSafe(win, PWORKSPACE);
+        }
+
+        g_pCompositor->focusWindow(windowsToMove.front());
+        g_pCompositor->warpCursorTo(windowsToMove.front()->middle());
+    }
     return {};
 }
 

--- a/hyprscrolling/Scrolling.hpp
+++ b/hyprscrolling/Scrolling.hpp
@@ -111,6 +111,11 @@ class CScrollingLayout : public IHyprLayout {
     SP<HOOK_CALLBACK_FN>            m_focusCallback;
 
     struct {
+        bool isMovingColumn    = false;
+        int  targetWorkspaceID = -1;
+    } m_columnMoveState;
+
+    struct {
         std::vector<float> configuredWidths;
     } m_config;
 


### PR DESCRIPTION
### Summary

This PR introduces two new layout messages for the `scrolling` layout: `swapcol` and `movecoltoworkspace`. These features significantly enhance workspace organization and address common user requests for more flexible column management.

### Motivation

As discussed in **Issue #431**, managing columns in the `scrolling` layout can be cumbersome. Users have pointed out the need for simpler ways to reorder columns and move them between workspaces without disrupting their internal structure. This PR directly addresses these needs by providing dedicated commands for these actions.

> As **@noctuid** noted:
> "Think this issue could be maybe more generic for column movement commands: directionally within a workspace and to move a column to another workspace"

This PR implements both of these suggestions.

### New Features

1.  **`swapcol [l|r]`**
    -   Swaps the currently focused column with its left or right neighbor.
    -   Features **cyclic (wrap-around) behavior**, allowing seamless reordering from one end of the workspace to the other.
    -   This resolves the tedious multi-step process for swapping windows/columns described in the issue.

2.  **`movecoltoworkspace [workspace]`**
    -   Moves the entire currently focused column to another workspace.
    -   **Preserves the column's state**, including the number of windows, their relative sizes, and their vertical order.
    -   Works flawlessly even when moving to an empty workspace by ensuring the target workspace uses the `scrolling` layout.

### Documentation

The `README.md` has been updated to include documentation and usage examples for both new commands.

---
Closes #431.