### PR TITLE
Hyprscrolling: feat: focus left/right moves to the best vertical neighbour

### DIFF
--- a/hyprscrolling/Scrolling.cpp
+++ b/hyprscrolling/Scrolling.cpp
@@ -787,9 +787,8 @@ SP<SScrollingWindowData> CScrollingLayout::findBestNeighbor(SP<SScrollingWindowD
 
         const bool   overlaps = (candidateTop < currentBottom) && (candidateBottom > currentTop);
 
-        if (overlaps)
-            if (!bestMatch || candidateTop < bestMatch->layoutBox.y)
-                bestMatch = candidate;
+        if (overlaps && (!bestMatch || candidateTop < bestMatch->layoutBox.y))
+            bestMatch = candidate;
     }
 
     if (!bestMatch && !pTargetCol->windowDatas.empty())

--- a/hyprscrolling/Scrolling.cpp
+++ b/hyprscrolling/Scrolling.cpp
@@ -774,30 +774,26 @@ void CScrollingLayout::fullscreenRequestForWindow(PHLWINDOW pWindow, const eFull
 }
 
 SP<SScrollingWindowData> CScrollingLayout::findBestNeighbor(SP<SScrollingWindowData> pCurrent, SP<SColumnData> pTargetCol) {
-    if (!pCurrent || !pTargetCol || pTargetCol->windowDatas.empty()) {
+    if (!pCurrent || !pTargetCol || pTargetCol->windowDatas.empty())
         return nullptr;
-    }
 
-    const double currentTop = pCurrent->layoutBox.y;
-    const double currentBottom = pCurrent->layoutBox.y + pCurrent->layoutBox.h;
-    SP<SScrollingWindowData> bestMatch = nullptr;
+    const double             currentTop    = pCurrent->layoutBox.y;
+    const double             currentBottom = pCurrent->layoutBox.y + pCurrent->layoutBox.h;
+    SP<SScrollingWindowData> bestMatch     = nullptr;
 
     for (const auto& candidate : pTargetCol->windowDatas) {
-        const double candidateTop = candidate->layoutBox.y;
+        const double candidateTop    = candidate->layoutBox.y;
         const double candidateBottom = candidate->layoutBox.y + candidate->layoutBox.h;
 
-        const bool overlaps = (candidateTop < currentBottom) && (candidateBottom > currentTop);
+        const bool   overlaps = (candidateTop < currentBottom) && (candidateBottom > currentTop);
 
-        if (overlaps) {
-            if (!bestMatch || candidateTop < bestMatch->layoutBox.y) {
+        if (overlaps)
+            if (!bestMatch || candidateTop < bestMatch->layoutBox.y)
                 bestMatch = candidate;
-            }
-        }
     }
 
-    if (!bestMatch && !pTargetCol->windowDatas.empty()) {
+    if (!bestMatch && !pTargetCol->windowDatas.empty())
         return pTargetCol->windowDatas.front();
-    }
 
     return bestMatch;
 }

--- a/hyprscrolling/Scrolling.hpp
+++ b/hyprscrolling/Scrolling.hpp
@@ -114,6 +114,7 @@ class CScrollingLayout : public IHyprLayout {
         std::vector<float> configuredWidths;
     } m_config;
 
+    SP<SScrollingWindowData> findBestNeighbor(SP<SScrollingWindowData> pCurrent, SP<SColumnData> pTargetCol);
     SP<SWorkspaceData>       dataFor(PHLWORKSPACE ws);
     SP<SScrollingWindowData> dataFor(PHLWINDOW w);
     SP<SWorkspaceData>       currentWorkspaceData();


### PR DESCRIPTION
### Problem 
When you have two (or more) columns with different numbers of windows,  `layoutmsg focus l/r` always sends focus to the **top-most** window of the adjacent column, even if the current window is at the bottom. This feels unnatural (issue #473).

### Solution  
Introduce `findBestNeighbor()` that selects the window in the target column whose vertical span **overlaps the current window the top**.  If no overlap exists we fall back to the top-most window, preserving the old behaviour for edge cases.

### Behaviour examples
```
    col1       col2
-----------------------
|  term A  |  term B  |
|  term A  |  term B  |
|  term A  |----------|
|  term A  |  term D  |
|----------|  term D  |<-- if focus is here, movefocus l goes to term A
|  term C  |  term D  |
|  term C  |----------|
|  term C  |  term E  |
|  term C  |  term E  |<-- if focus is here, movefocus l goes to term C
-----------------------
 ```

### Testing done  
- Built and ran locally with 2 & 3 column layouts.  
- All focus left/right movements now go to the visually nearest window.  
- No regressions when columns have identical or single-window height.

Closes #473