### PR TITLE
Hyprscrolling: feat: improve focus stability with last-focused memory

### DIFF
--- a/borders-plus-plus/default.nix
+++ b/borders-plus-plus/default.nix
@@ -3,7 +3,7 @@
   hyprland,
   hyprlandPlugins,
 }:
-hyprlandPlugins.mkHyprlandPlugin hyprland {
+hyprlandPlugins.mkHyprlandPlugin {
   pluginName = "borders-plus-plus";
   version = "0.1";
   src = ./.;

--- a/csgo-vulkan-fix/default.nix
+++ b/csgo-vulkan-fix/default.nix
@@ -3,7 +3,7 @@
   hyprland,
   hyprlandPlugins,
 }:
-hyprlandPlugins.mkHyprlandPlugin hyprland {
+hyprlandPlugins.mkHyprlandPlugin {
   pluginName = "csgo-vulkan-fix";
   version = "0.1";
   src = ./.;

--- a/flake.lock
+++ b/flake.lock
@@ -116,11 +116,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755678602,
-        "narHash": "sha256-uEC5O/NIUNs1zmc1aH1+G3GRACbODjk2iS0ET5hXtuk=",
+        "lastModified": 1758192433,
+        "narHash": "sha256-CR6RnqEJSTiFgA6KQY4TTLUWbZ8RBnb+hxQqesuQNzQ=",
         "owner": "hyprwm",
         "repo": "hyprgraphics",
-        "rev": "157cc52065a104fc3b8fa542ae648b992421d1c7",
+        "rev": "c44e749dd611521dee940d00f7c444ee0ae4cfb7",
         "type": "github"
       },
       "original": {
@@ -145,11 +145,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1756372920,
-        "narHash": "sha256-kUTDPrbBksfu/xbwyD8NAMUcu/D5jWwiCEfANgxCnG4=",
+        "lastModified": 1758293956,
+        "narHash": "sha256-+UCEuPcCsWkyQh73KouiVZmcsW6ljVKHUUXDcJNI41w=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "4b2bfbd85f1ea77a165d9ba92d62016cdf3abfcd",
+        "rev": "88326075743a677e76645ff163b392490419d4de",
         "type": "github"
       },
       "original": {
@@ -238,11 +238,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753819801,
-        "narHash": "sha256-tHe6XeNeVeKapkNM3tcjW4RuD+tB2iwwoogWJOtsqTI=",
+        "lastModified": 1757694755,
+        "narHash": "sha256-j+w5QUUr2QT/jkxgVKecGYV8J7fpzXCMgzEEr6LG9ug=",
         "owner": "hyprwm",
         "repo": "hyprland-qtutils",
-        "rev": "b308a818b9dcaa7ab8ccab891c1b84ebde2152bc",
+        "rev": "5ffdfc13ed03df1dae5084468d935f0a3f2c9a4c",
         "type": "github"
       },
       "original": {
@@ -267,11 +267,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753622892,
-        "narHash": "sha256-0K+A+gmOI8IklSg5It1nyRNv0kCNL51duwnhUO/B8JA=",
+        "lastModified": 1756810301,
+        "narHash": "sha256-wgZ3VW4VVtjK5dr0EiK9zKdJ/SOqGIBXVG85C3LVxQA=",
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "rev": "23f0debd2003f17bd65f851cd3f930cff8a8c809",
+        "rev": "3d63fb4a42c819f198deabd18c0c2c1ded1de931",
         "type": "github"
       },
       "original": {
@@ -332,11 +332,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1756266583,
-        "narHash": "sha256-cr748nSmpfvnhqSXPiCfUPxRz2FJnvf/RjJGvFfaCsM=",
+        "lastModified": 1758198701,
+        "narHash": "sha256-7To75JlpekfUmdkUZewnT6MoBANS0XVypW6kjUOXQwc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8a6d5427d99ec71c64f0b93d45778c889005d9c2",
+        "rev": "0147c2f1d54b30b5dd6d4a8c8542e8d7edf93b5d",
         "type": "github"
       },
       "original": {
@@ -356,11 +356,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755960406,
-        "narHash": "sha256-RF7j6C1TmSTK9tYWO6CdEMtg6XZaUKcvZwOCD2SICZs=",
+        "lastModified": 1758108966,
+        "narHash": "sha256-ytw7ROXaWZ7OfwHrQ9xvjpUWeGVm86pwnEd1QhzawIo=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "e891a93b193fcaf2fc8012d890dc7f0befe86ec2",
+        "rev": "54df955a695a84cd47d4a43e08e1feaf90b1fd9b",
         "type": "github"
       },
       "original": {

--- a/hyprbars/default.nix
+++ b/hyprbars/default.nix
@@ -3,7 +3,7 @@
   hyprland,
   hyprlandPlugins,
 }:
-hyprlandPlugins.mkHyprlandPlugin hyprland {
+hyprlandPlugins.mkHyprlandPlugin {
   pluginName = "hyprbars";
   version = "0.1";
   src = ./.;

--- a/hyprexpo/default.nix
+++ b/hyprexpo/default.nix
@@ -3,7 +3,7 @@
   hyprland,
   hyprlandPlugins,
 }:
-hyprlandPlugins.mkHyprlandPlugin hyprland {
+hyprlandPlugins.mkHyprlandPlugin {
   pluginName = "hyprexpo";
   version = "0.1";
   src = ./.;

--- a/hyprfocus/default.nix
+++ b/hyprfocus/default.nix
@@ -3,7 +3,7 @@
   hyprland,
   hyprlandPlugins,
 }:
-hyprlandPlugins.mkHyprlandPlugin hyprland {
+hyprlandPlugins.mkHyprlandPlugin {
   pluginName = "hyprfocus";
   version = "0.1";
   src = ./.;

--- a/hyprscrolling/Scrolling.cpp
+++ b/hyprscrolling/Scrolling.cpp
@@ -773,28 +773,49 @@ void CScrollingLayout::fullscreenRequestForWindow(PHLWINDOW pWindow, const eFull
     g_pCompositor->changeWindowZOrder(pWindow, true);
 }
 
+void CScrollingLayout::focusWindowUpdate(PHLWINDOW pWindow) {
+    if (!validMapped(pWindow)) {
+        g_pCompositor->focusWindow(nullptr);
+        return;
+    }
+    g_pCompositor->focusWindow(pWindow);
+    const auto WINDOWDATA = dataFor(pWindow);
+    if (WINDOWDATA)
+        if (auto col = WINDOWDATA->column.lock())
+            col->lastFocusedWindow = WINDOWDATA;
+}
+
 SP<SScrollingWindowData> CScrollingLayout::findBestNeighbor(SP<SScrollingWindowData> pCurrent, SP<SColumnData> pTargetCol) {
     if (!pCurrent || !pTargetCol || pTargetCol->windowDatas.empty())
         return nullptr;
 
-    const double             currentTop    = pCurrent->layoutBox.y;
-    const double             currentBottom = pCurrent->layoutBox.y + pCurrent->layoutBox.h;
-    SP<SScrollingWindowData> bestMatch     = nullptr;
-
+    const double                          currentTop    = pCurrent->layoutBox.y;
+    const double                          currentBottom = pCurrent->layoutBox.y + pCurrent->layoutBox.h;
+    std::vector<SP<SScrollingWindowData>> overlappingWindows;
     for (const auto& candidate : pTargetCol->windowDatas) {
         const double candidateTop    = candidate->layoutBox.y;
         const double candidateBottom = candidate->layoutBox.y + candidate->layoutBox.h;
+        const bool   overlaps        = (candidateTop < currentBottom) && (candidateBottom > currentTop);
 
-        const bool   overlaps = (candidateTop < currentBottom) && (candidateBottom > currentTop);
-
-        if (overlaps && (!bestMatch || candidateTop < bestMatch->layoutBox.y))
-            bestMatch = candidate;
+        if (overlaps)
+            overlappingWindows.push_back(candidate);
     }
+    if (!overlappingWindows.empty()) {
+        auto lastFocused = pTargetCol->lastFocusedWindow.lock();
 
-    if (!bestMatch && !pTargetCol->windowDatas.empty())
+        if (lastFocused) {
+            auto it = std::find(overlappingWindows.begin(), overlappingWindows.end(), lastFocused);
+            if (it != overlappingWindows.end())
+                return lastFocused;
+        }
+
+        auto topmost = std::min_element(overlappingWindows.begin(), overlappingWindows.end(), [](const auto& a, const auto& b) { return a->layoutBox.y < b->layoutBox.y; });
+
+        return *topmost;
+    }
+    if (!pTargetCol->windowDatas.empty())
         return pTargetCol->windowDatas.front();
-
-    return bestMatch;
+    return nullptr;
 }
 
 std::any CScrollingLayout::layoutMessage(SLayoutMessageHeader header, std::string message) {
@@ -822,14 +843,14 @@ std::any CScrollingLayout::layoutMessage(SLayoutMessageHeader header, std::strin
                 // move to max
                 DATA->leftOffset = DATA->maxWidth();
                 DATA->recalculate();
-                g_pCompositor->focusWindow(nullptr);
+                focusWindowUpdate(nullptr);
                 return {};
             }
 
             centerOrFit(DATA, COL);
             DATA->recalculate();
 
-            g_pCompositor->focusWindow(COL->windowDatas.front()->window.lock());
+            focusWindowUpdate(COL->windowDatas.front()->window.lock());
             g_pCompositor->warpCursorTo(COL->windowDatas.front()->window.lock()->middle());
 
             return {};
@@ -839,7 +860,7 @@ std::any CScrollingLayout::layoutMessage(SLayoutMessageHeader header, std::strin
                 if (DATA->leftOffset <= DATA->maxWidth() && DATA->columns.size() > 0) {
                     DATA->centerCol(DATA->columns.back());
                     DATA->recalculate();
-                    g_pCompositor->focusWindow((DATA->columns.back()->windowDatas.back())->window.lock());
+                    focusWindowUpdate((DATA->columns.back()->windowDatas.back())->window.lock());
                     g_pCompositor->warpCursorTo((DATA->columns.back()->windowDatas.back())->window.lock()->middle());
                 }
 
@@ -853,7 +874,7 @@ std::any CScrollingLayout::layoutMessage(SLayoutMessageHeader header, std::strin
             centerOrFit(DATA, COL);
             DATA->recalculate();
 
-            g_pCompositor->focusWindow(COL->windowDatas.back()->window.lock());
+            focusWindowUpdate(COL->windowDatas.back()->window.lock());
             g_pCompositor->warpCursorTo(COL->windowDatas.front()->window.lock()->middle());
 
             return {};
@@ -869,7 +890,7 @@ std::any CScrollingLayout::layoutMessage(SLayoutMessageHeader header, std::strin
 
         const auto ATCENTER = DATA->atCenter();
 
-        g_pCompositor->focusWindow(ATCENTER ? (*ATCENTER->windowDatas.begin())->window.lock() : nullptr);
+        focusWindowUpdate(ATCENTER ? (*ATCENTER->windowDatas.begin())->window.lock() : nullptr);
     } else if (ARGS[0] == "colresize") {
         const auto WDATA = dataFor(g_pCompositor->m_lastWindow.lock());
 
@@ -1100,7 +1121,7 @@ std::any CScrollingLayout::layoutMessage(SLayoutMessageHeader header, std::strin
                         PREV = WDATA->column->windowDatas.back();
                 }
 
-                g_pCompositor->focusWindow(PREV->window.lock());
+                focusWindowUpdate(PREV->window.lock());
                 g_pCompositor->warpCursorTo(PREV->window.lock()->middle());
                 break;
             }
@@ -1115,7 +1136,7 @@ std::any CScrollingLayout::layoutMessage(SLayoutMessageHeader header, std::strin
                         NEXT = WDATA->column->windowDatas.front();
                 }
 
-                g_pCompositor->focusWindow(NEXT->window.lock());
+                focusWindowUpdate(NEXT->window.lock());
                 g_pCompositor->warpCursorTo(NEXT->window.lock()->middle());
                 break;
             }
@@ -1133,10 +1154,12 @@ std::any CScrollingLayout::layoutMessage(SLayoutMessageHeader header, std::strin
                 }
 
                 auto pTargetWindowData = findBestNeighbor(WDATA, PREV);
-                g_pCompositor->focusWindow(pTargetWindowData->window.lock());
-                centerOrFit(WDATA->column->workspace.lock(), PREV);
-                WDATA->column->workspace->recalculate();
-                g_pCompositor->warpCursorTo(PREV->windowDatas.front()->window.lock()->middle());
+                if (pTargetWindowData) {
+                    focusWindowUpdate(pTargetWindowData->window.lock());
+                    centerOrFit(WDATA->column->workspace.lock(), PREV);
+                    WDATA->column->workspace->recalculate();
+                    g_pCompositor->warpCursorTo(pTargetWindowData->window.lock()->middle());
+                }
                 break;
             }
 
@@ -1153,10 +1176,12 @@ std::any CScrollingLayout::layoutMessage(SLayoutMessageHeader header, std::strin
                 }
 
                 auto pTargetWindowData = findBestNeighbor(WDATA, NEXT);
-                g_pCompositor->focusWindow(pTargetWindowData->window.lock());
-                centerOrFit(WDATA->column->workspace.lock(), NEXT);
-                WDATA->column->workspace->recalculate();
-                g_pCompositor->warpCursorTo(NEXT->windowDatas.front()->window.lock()->middle());
+                if (pTargetWindowData) {
+                    focusWindowUpdate(pTargetWindowData->window.lock());
+                    centerOrFit(WDATA->column->workspace.lock(), NEXT);
+                    WDATA->column->workspace->recalculate();
+                    g_pCompositor->warpCursorTo(pTargetWindowData->window.lock()->middle());
+                }
                 break;
             }
 
@@ -1237,6 +1262,7 @@ void CScrollingLayout::moveWindowTo(PHLWINDOW w, const std::string& dir, bool si
         DATA->column->down(DATA);
 
     WS->recalculate();
+    focusWindowUpdate(w);
     g_pCompositor->warpCursorTo(w->middle());
 }
 

--- a/hyprscrolling/Scrolling.hpp
+++ b/hyprscrolling/Scrolling.hpp
@@ -47,6 +47,7 @@ struct SColumnData {
     float                                 columnSize  = 1.F;
     float                                 columnWidth = 1.F;
     WP<SWorkspaceData>                    workspace;
+    WP<SScrollingWindowData>              lastFocusedWindow;
 
     WP<SColumnData>                       self;
 };
@@ -120,6 +121,7 @@ class CScrollingLayout : public IHyprLayout {
     SP<SWorkspaceData>       currentWorkspaceData();
 
     void                     applyNodeDataToWindow(SP<SScrollingWindowData> node, bool instant, bool hasWindowsRight, bool hasWindowsLeft);
+    void                     focusWindowUpdate(PHLWINDOW pWindow);
 
     friend struct SWorkspaceData;
 };

--- a/hyprscrolling/default.nix
+++ b/hyprscrolling/default.nix
@@ -3,7 +3,7 @@
   hyprland,
   hyprlandPlugins,
 }:
-hyprlandPlugins.mkHyprlandPlugin hyprland {
+hyprlandPlugins.mkHyprlandPlugin {
   pluginName = "hyprscrolling";
   version = "0.1";
   src = ./.;

--- a/hyprtrails/default.nix
+++ b/hyprtrails/default.nix
@@ -3,7 +3,7 @@
   hyprland,
   hyprlandPlugins,
 }:
-hyprlandPlugins.mkHyprlandPlugin hyprland {
+hyprlandPlugins.mkHyprlandPlugin {
   pluginName = "hyprtrails";
   version = "0.1";
   src = ./.;

--- a/hyprwinwrap/default.nix
+++ b/hyprwinwrap/default.nix
@@ -3,7 +3,7 @@
   hyprland,
   hyprlandPlugins,
 }:
-hyprlandPlugins.mkHyprlandPlugin hyprland {
+hyprlandPlugins.mkHyprlandPlugin {
   pluginName = "hyprwinwrap";
   version = "0.1";
   src = ./.;

--- a/xtra-dispatchers/default.nix
+++ b/xtra-dispatchers/default.nix
@@ -3,7 +3,7 @@
   hyprland,
   hyprlandPlugins,
 }:
-hyprlandPlugins.mkHyprlandPlugin hyprland {
+hyprlandPlugins.mkHyprlandPlugin {
   pluginName = "xtra-dispatchers";
   version = "0.1";
   src = ./.;


### PR DESCRIPTION
This PR introduces a more intelligent focus behavior for the scrolling layout, resolving issues where focus would jump unpredictably when moving between columns with different window arrangements.

**Changes:**

1.  **Last Focused Window Tracking:** Each column now remembers the last window that had focus within it via a `WP<SScrollingWindowData> lastFocusedWindow`.
2.  **New `findBestNeighbor` Logic:** The algorithm for finding the next window to focus when moving left or right has been rewritten. It now:
    *   Prioritizes the `lastFocusedWindow` in the target column, but only if it vertically overlaps with the current window.
    *   Falls back to the top-most vertically overlapping window if the historical choice is not applicable.
    *   Falls back again to the first window in the column if there is no overlap at all.
3.  **Proactive Focus Update:** A new helper function, `focusWindowUpdate()`, has been introduced. This function wraps the call to `g_pCompositor->focusWindow()` and immediately updates the `lastFocusedWindow` state for the target column. This solves edge cases where the `activeWindow` hook might not fire, for example, when moving an already-focused window to a new column.
4.  **Integration:** All layout-initiated focus changes now use `focusWindowUpdate()` to ensure state consistency.

**Why these changes were made:**
Like @stephenh mentioned in #473:
> ```
>     col1       col2
> -----------------------
> |  term A  |  term C  |
> |  term A  |  term C  |
> |----------|  term C  |
> |  term B  |  term C  |
> |  term B  |  term C  |
> -----------------------
> ```
> 
> And want to continually flip between "term B <=> term C" while I'm debugging something, and I'm constantly being thrown off by "gah I'm back in term A again".

Originally, I came up with 2 approaches:

> * Consider a hybird approach:
>   
>   1. **Remember Last Focused Window:** Each column would store a reference (e.g., a `weak_ptr`) to the last window that had focus within it. Let's call it `lastFocusedWindow`.
>   2. **Prioritize History:** When you execute a `focus l` or `focus r` command, the logic would first check the target column's `lastFocusedWindow`.
>      
>      * If that window still exists, we immediately focus it. This would perfectly solve your `B <=> C` scenario. When you move from B to C, column 1's "memory" is now B. When you move back from C, it will jump straight to B, creating a stable and predictable cycle.
>   3. **Use Geometry as a Fallback:** If the target column has no `lastFocusedWindow` (e.g., you've never focused a window in it, or the last-focused window has since been closed), we would then fall back to using the heuristic.
> * Check the "overlaped window set"
>   
>   1. We consider all overlaped windows in a set $S$. If `LastFocusedWindow` in $S$, we then focus it.
>   2. `LastFocusedWindow` not in $S$, we fallback to focus the top-most, which is the current heuristic method.

From my perspective, method 2 is more intuitive in this senariao:
> ```
> col 1, term A    | col2, term B
> col 1, term C    | col2, term D
> ```
> 
> If I move focus like `B->A->C`，in this situation normally we perhaps more likely move to `D` rather than `C`.

So I implemented method 2.