### PR TITLE
Hyprscrolling: fix `layoutmsg fit visible` incorrectly include window at the border

### DIFF
--- a/hyprscrolling/Scrolling.cpp
+++ b/hyprscrolling/Scrolling.cpp
@@ -329,9 +329,13 @@ bool SWorkspaceData::visible(SP<SColumnData> c) {
     const auto USABLE    = layout->usableAreaFor(workspace->m_monitor.lock());
     float      totalLeft = 0;
     for (const auto& col : columns) {
-        if (col == c)
-            return (totalLeft >= leftOffset && totalLeft < leftOffset + USABLE.w) ||
-                (totalLeft + col->columnWidth * USABLE.w >= leftOffset && totalLeft + col->columnWidth * USABLE.w < leftOffset + USABLE.w);
+        if (col == c) {
+            const float colLeft   = totalLeft;
+            const float colRight  = totalLeft + col->columnWidth * USABLE.w;
+            const float viewLeft  = leftOffset;
+            const float viewRight = leftOffset + USABLE.w;
+            return colLeft < viewRight && viewLeft < colRight;
+        }
 
         totalLeft += col->columnWidth * USABLE.w;
     }

--- a/hyprscrolling/Scrolling.hpp
+++ b/hyprscrolling/Scrolling.hpp
@@ -58,7 +58,7 @@ struct SWorkspaceData {
 
     PHLWORKSPACEREF              workspace;
     std::vector<SP<SColumnData>> columns;
-    int                          leftOffset = 0;
+    float                        leftOffset = 0;
 
     SP<SColumnData>              add();
     SP<SColumnData>              add(int after);


### PR DESCRIPTION
After the first `fit visible`, columns whose **right edge is already outside the viewport** are still treated as “visible” and are counted into the final layout.  
This results in:

1. A column that is almost completely off-screen (only a few pixels on the left edge) is kept.  
2. The remaining space is evenly divided among the “visible” columns, so the actually visible windows become unnecessarily narrow.  
3. A second `fit visible` usually “fixes” it, because the first call has already dragged the rogue column fully into view.

The root cause is the old visibility test:

```cpp
(totalLeft >= leftOffset && totalLeft < leftOffset + USABLE.w) ||
(totalLeft + col->width >= leftOffset && totalLeft + col->width < leftOffset + USABLE.w)
```

It only accepts a column when **either** its left **or** its right border is **strictly inside** the viewport.  
For a column that is *completely outside on the left* (`colRight < viewLeft`) the test still returns true because the **left** border check passes.

Replace it with the canonical “AABB” overlap test:

```cpp
colLeft < viewRight && viewLeft < colRight
```

which is both simpler and correct.

While touching the code, also change the type of `leftOffset` from `int` to `float` to avoid repeated silent conversions.

### Reproduce steps
0. Set `column_width = 0.60`
1. Open 3 columns in hyprscrolling.  
2. `hyprctl dispatch layoutmsg fit visible` 
3. Repeat 2. 