### PR TITLE
Hyprscrolling: fix window size disturbance on focus change

### DIFF
--- a/hyprscrolling/Scrolling.cpp
+++ b/hyprscrolling/Scrolling.cpp
@@ -366,8 +366,8 @@ void CScrollingLayout::applyNodeDataToWindow(SP<SScrollingWindowData> data, bool
     }
 
     // for gaps outer
-    const bool DISPLAYLEFT   = !hasWindowsLeft && STICKS(data->layoutBox.x, PMONITOR->m_position.x + PMONITOR->m_reservedTopLeft.x);
-    const bool DISPLAYRIGHT  = !hasWindowsRight && STICKS(data->layoutBox.x + data->layoutBox.w, PMONITOR->m_position.x + PMONITOR->m_size.x - PMONITOR->m_reservedBottomRight.x);
+    const bool DISPLAYLEFT   = !hasWindowsLeft;
+    const bool DISPLAYRIGHT  = !hasWindowsRight;
     const bool DISPLAYTOP    = STICKS(data->layoutBox.y, PMONITOR->m_position.y + PMONITOR->m_reservedTopLeft.y);
     const bool DISPLAYBOTTOM = STICKS(data->layoutBox.y + data->layoutBox.h, PMONITOR->m_position.y + PMONITOR->m_size.y - PMONITOR->m_reservedBottomRight.y);
 


### PR DESCRIPTION
### Description

This pull request fixes an issue where the window size would be disturbed when changing focus during a scroll operation, causing flashes of windows like neovim.

### Reason for the fix

The root cause of the issue was the use of the `STICKS` macro to determine whether a window should have outer gaps (`gaps_out`) or inner gaps (`gaps_in`). The `STICKS` macro checks if a window's edge is physically close to the monitor's edge.

During a scrolling animation, a window's position changes continuously. This caused the result of the `STICKS` check to flicker between `true` and `false`. When a focus change occurred during the scroll, it triggered a recalculation of the window size. Due to the unstable `STICKS` result, the applied gap would rapidly switch between `gaps_in` and `gaps_out`, leading to the observed window size disturbance.

This change removes the `STICKS` check. The decision to apply outer or inner gaps now solely depends on whether a column is the leftmost or rightmost in the layout (`hasWindowsLeft` / `hasWindowsRight`). This condition is stable during the scrolling animation, thus resolving the issue.

### Verification

This fix has been tested and confirmed to resolve the window size disturbance issue during focus changes while scrolling. The window sizes now remain stable.