### PR TITLE
scrolling: remove redundant workspace check

### DIFF
--- a/hyprscrolling/Scrolling.cpp
+++ b/hyprscrolling/Scrolling.cpp
@@ -275,7 +275,7 @@ SP<SColumnData> SWorkspaceData::atCenter() {
 void SWorkspaceData::recalculate(bool forceInstant) {
     static const auto PFSONONE = CConfigValue<Hyprlang::INT>("plugin:hyprscrolling:fullscreen_on_one_column");
 
-    if (!workspace || !workspace) {
+    if (!workspace) {
         Debug::log(ERR, "[scroller] broken internal state on workspace data");
         return;
     }


### PR DESCRIPTION
Fixes #503 

Removes second redundant check.

```cpp
if (!workspace || !workspace) {
        Debug::log(ERR, "[scroller] broken internal state on workspace data");
        return;
}
```
https://github.com/hyprwm/hyprland-plugins/blob/7be897d6ae765fab756c0b7e6b91e8c5b39a419e/hyprscrolling/Scrolling.cpp#L278C3-L281C6

Changed to
```cpp
if (!workspace) {
        Debug::log(ERR, "[scroller] broken internal state on workspace data");
        return;
}
```