### PR TITLE
fix(hyprexpo): correct workspace wrap logic in center mode / intuitive named workspaces

### DIFF
--- a/hyprexpo/overview.cpp
+++ b/hyprexpo/overview.cpp
@@ -91,7 +91,7 @@ COverview::COverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn
                 currentID = getWorkspaceIDNameFromString(selector + std::to_string((int64_t)i - backtracked)).id;
             } else {
                 currentID = getWorkspaceIDNameFromString(selector + "+" + std::to_string((int64_t)i - backtracked)).id;
-                if (i > 0 && currentID <= firstID)
+                if (i > 0 && currentID == firstID)
                     break;
             }
             image.workspaceID = currentID;


### PR DESCRIPTION
This PR fixes a bug in hyprexpo center workspace mode that caused empty and incorrect wrapping and un-intuitive ordering for named workspaces (which are represented by negative IDs). The picker previously used a condition that prevented wrapping and left empty slots to the right of the center when the selected workspace was at the end of the active set. The fix changes a single comparison to allow the algorithm to continue filling available slots.

Problem reproduction and behavior after the fix:
Configure Hyprland with named workspaces (Hyprland assigns IDs like -1337 and lower).

Create 8 active workspaces and select the 8th workspace.

config: Center Current (3x3 grid)
Workspaces: 1, 2, 3, 4, 5, A, B, C 
Current: 5

Shown: 2, 3, 4, 5, empty, empty, empty, empty, empty.
Shown after the fix: 2, 3, 4, 5, C, B, A, 1, empty (Order of letters may vary since they get an ID on opening order)

Root cause:
The loop that populates the previews used if (i > 0 && currentID <= firstID) which never allowed wrap-arounds.

Fix implemented:
Change the condition to if (i > 0 && currentID == firstID) so the loop only stops when the iterator returns to the starting workspace, allowing the picker to wrap and fill remaining visible slots with the next active workspaces.


I may be missing something as to why the implementation didn't follow warp-around in the first place, there may be a good reason (?), if this is the case, may I add a config option for wrap-around? I would very much prefer this behavior for quick switching between 9 workspaces per-monitor instead of needing to worry about which is selected and only being able to see part of the active workspaces + half the screen with empty one

linked issue i found: #143 