### PR TITLE
build: remove version from top-level cmakelists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.27)
 project(hyprland-plugins
-    VERSION 0.51.0
     DESCRIPTION "Official plugins for Hyprland"
     LANGUAGES CXX
 )


### PR DESCRIPTION
have seen other hypr* projects use this approach too,
might be useful to just bump the version-file when creating a new release.

changes:
- add VERSION file
- CMakeLists.txt integration: parse version from given VERSION file