### PR TITLE
hyprfocus: fix fullscreen windows not restoring original state

### DIFF
--- a/hyprfocus/main.cpp
+++ b/hyprfocus/main.cpp
@@ -77,7 +77,7 @@ static void onFocusChange(PHLWINDOW window) {
             w->m_realSize->setConfig(POUT);
             w->m_realPosition->setConfig(POUT);
 
-            if (w->m_isFloating) {
+            if (w->m_isFloating || w->isFullscreen()) {
                 *w->m_realPosition = ORIGINAL.pos();
                 *w->m_realSize     = ORIGINAL.size();
             } else
@@ -97,7 +97,7 @@ static void onFocusChange(PHLWINDOW window) {
                 return;
             w->m_realPosition->setConfig(POUT);
 
-            if (w->m_isFloating)
+            if (w->m_isFloating || w->isFullscreen())
                 *w->m_realPosition = ORIGINAL;
             else
                 g_pLayoutManager->getCurrentLayout()->recalculateWindow(w.lock());


### PR DESCRIPTION
If you have:

- hyprfocus running in slide or bounce mode
- at least two monitors
- and at least one fullscreen window open (internal `fullscreenstate` > 0)

then, upon focusing the fullscreen window, hyprfocus doesn't seem to restore it after performing the animation,
leaving it stuck in a [slid up](https://github.com/user-attachments/assets/13984daa-2c10-47dd-8780-4146d39426c3) or [zoomed in](https://github.com/user-attachments/assets/4e8696d0-a97c-46ee-ba72-9ecad03a09d4) state.

Tested with Hyprland v0.52.1 and hyprland-plugins v0.52.0 on NixOS unstable (rev `9da7f1cf7f8a6e2a7cb3001b048546c92a8258b4`):
- `/nix/store/m7ry8mvzqr6gmmw30fzzkx5jkq60n8hl-hyprland-0.52.1`
- `/nix/store/hh9zqxm96xvvlmgwvaqn5gnqj4758zfz-hyprfocus-0.52.0`

Running the `isFloating` restore logic on fullscreen windows fixes this issue.