### PR TITLE
hyprfocus: add only_on_monitor_change option

### DIFF
--- a/hyprfocus/README.md
+++ b/hyprfocus/README.md
@@ -14,9 +14,10 @@ animation = hyprfocusOut, 1, 1.7, myCurve2
 
 ### Variables
 
-| name | description | type | default |
-| --- | --- | --- | --- |
-|mode|which mode to use (flash / bounce / slide) | str | flash |
-| fade_opacity | for flash, what opacity to flash to | float | 0.8 |
-| bounce_strength | for bounce, what fraction of the window's size to jump to | float | 0.95 |
-| slide_height | for slide, how far up to slide | float | 20 |
+| name                     | description                                                          | type    | default |
+|--------------------------|----------------------------------------------------------------------|---------|---------|
+| `mode`                   | which mode to use (flash / bounce / slide)                           | str     | flash   |
+| `only_on_monitor_change` | whether to only perform the animation when changing between monitors | boolean | false   |
+| `fade_opacity`           | for flash, what opacity to flash to                                  | float   | 0.8     |
+| `bounce_strength`        | for bounce, what fraction of the window's size to jump to            | float   | 0.95    |
+| `slide_height`           | for slide, how far up to slide                                       | float   | 20      |

--- a/hyprfocus/main.cpp
+++ b/hyprfocus/main.cpp
@@ -38,6 +38,10 @@ static void onFocusChange(PHLWINDOW window) {
     if (lastWindow == window)
         return;
 
+    static const auto PONLY_ON_MONITOR_CHANGE = CConfigValue<Hyprlang::INT>("plugin:hyprfocus:only_on_monitor_change");
+    if (*PONLY_ON_MONITOR_CHANGE && lastWindow && lastWindow->m_monitor == window->m_monitor)
+        return;
+
     lastWindow = window;
 
     static const auto POPACITY = CConfigValue<Hyprlang::FLOAT>("plugin:hyprfocus:fade_opacity");
@@ -124,6 +128,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     // clang-format on
 
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprfocus:mode", Hyprlang::STRING{"flash"});
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprfocus:only_on_monitor_change", Hyprlang::INT{0});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprfocus:fade_opacity", Hyprlang::FLOAT{0.8F});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprfocus:slide_height", Hyprlang::FLOAT{20.F});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprfocus:bounce_strength", Hyprlang::FLOAT{0.95F});


### PR DESCRIPTION
This adds the `plugin:hyprfocus:only_on_monitor_change` option, which, if enabled, makes hyprfocus only animate a window if the previously selected one was on a different monitor.

This is primarily intended for [smart gaps](https://wiki.hypr.land/Configuring/Workspace-Rules/#smart-gaps) configurations, where:
- switching between windows on the same monitor is indicated by the border and thus doesn't require extra visual "noise" from hyprfocus
- but switching between lone windows on multiple monitors should be clearly marked by hyprfocus, since those windows won't have a visible border