### PR TITLE
hyprscrolling: fixed moveWindowTo behavior

### DIFF
--- a/hyprscrolling/Scrolling.cpp
+++ b/hyprscrolling/Scrolling.cpp
@@ -68,7 +68,7 @@ size_t SColumnData::idxForHeight(float y) {
     for (size_t i = 0; i < windowDatas.size(); ++i) {
         if (windowDatas[i]->window->m_position.y < y)
             continue;
-        return i;
+        return i - 1;
     }
     return windowDatas.size() - 1;
 }
@@ -1446,7 +1446,7 @@ void CScrollingLayout::moveWindowTo(PHLWINDOW w, const std::string& dir, bool si
             WS->centerOrFitCol(NEWCOL);
         } else {
             if (COL->windowDatas.size() > 0)
-                COL->add(DATA, COL->idxForHeight(g_pInputManager->getMouseCoordsInternal().y) - 1);
+                COL->add(DATA, COL->idxForHeight(g_pInputManager->getMouseCoordsInternal().y));
             else
                 COL->add(DATA);
             WS->centerOrFitCol(COL);
@@ -1463,7 +1463,7 @@ void CScrollingLayout::moveWindowTo(PHLWINDOW w, const std::string& dir, bool si
             WS->centerOrFitCol(NEWCOL);
         } else {
             if (COL->windowDatas.size() > 0)
-                COL->add(DATA, COL->idxForHeight(g_pInputManager->getMouseCoordsInternal().y) - 1);
+                COL->add(DATA, COL->idxForHeight(g_pInputManager->getMouseCoordsInternal().y));
             else
                 COL->add(DATA);
             WS->centerOrFitCol(COL);

--- a/hyprscrolling/Scrolling.hpp
+++ b/hyprscrolling/Scrolling.hpp
@@ -35,6 +35,8 @@ struct SColumnData {
     void                                  remove(PHLWINDOW w);
     bool                                  has(PHLWINDOW w);
     size_t                                idx(PHLWINDOW w);
+
+    // index of lowest window that is above y.
     size_t                                idxForHeight(float y);
 
     void                                  up(SP<SScrollingWindowData> w);


### PR DESCRIPTION
The `return i - 1` line in `idxForHeight` was causing a crash when called inside `moveWindowTo`, specifically when the cursor was at the top of the screen. After changing the check in the line right before that call, this also fixes #422 .