### PR TITLE
hyprscrolling: fixed `layoutmsg, move -col`

### DIFF
--- a/hyprscrolling/Scrolling.cpp
+++ b/hyprscrolling/Scrolling.cpp
@@ -865,7 +865,7 @@ std::any CScrollingLayout::layoutMessage(SLayoutMessageHeader header, std::strin
         } else if (ARGS[1] == "-col") {
             const auto WDATA = dataFor(Desktop::focusState()->window());
             if (!WDATA) {
-                if (DATA->leftOffset <= DATA->maxWidth() && DATA->columns.size() > 0) {
+                if (DATA->columns.size() > 0) {
                     DATA->centerCol(DATA->columns.back());
                     DATA->recalculate();
                     focusWindowUpdate((DATA->columns.back()->windowDatas.back())->window.lock());


### PR DESCRIPTION
fixes #553.

When the line `DATA->leftOffset = DATA->maxWidth` was called previously by the user (inside of the `+col` logic), it would sometimes round `DATA->maxWidth` up. Since this check didn't cast `maxWidth`, it failed when it shouldn't have.

I just removed that half of the check entirely because I can't imagine a scenario where you wouldn't want to return to the last column.