### PR TITLE
hyprscrolling: remove notification on successfull load

### DIFF
--- a/hyprscrolling/main.cpp
+++ b/hyprscrolling/main.cpp
@@ -51,9 +51,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprscrolling:explicit_column_widths", Hyprlang::STRING{"0.333, 0.5, 0.667, 1.0"});
     HyprlandAPI::addLayout(PHANDLE, "scrolling", g_pScrollingLayout.get());
 
-    if (success)
-        HyprlandAPI::addNotification(PHANDLE, "[hyprscrolling] Initialized successfully!", CHyprColor{0.2, 1.0, 0.2, 1.0}, 5000);
-    else {
+    if (!success) {
         HyprlandAPI::addNotification(PHANDLE, "[hyprscrolling] Failure in initialization: failed to register dispatchers", CHyprColor{1.0, 0.2, 0.2, 1.0}, 5000);
         throw std::runtime_error("[hs] Dispatchers failed");
     }


### PR DESCRIPTION
Generating notification on failure only. With respect to hyprexpo, it also shows notification on failure only.

Fixes: starting Hyprland and being greeted with `Hyprscrolling loaded successfully`.