### PR TITLE
build: Update Makefiles to allow CXX, CXXFLAGS, LDFLAGS env vars

### DIFF
--- a/borders-plus-plus/Makefile
+++ b/borders-plus-plus/Makefile
@@ -5,8 +5,11 @@ else
     EXTRA_FLAGS =
 endif
 
+CXXFLAGS ?= -O2
+CXXFLAGS += -shared -fPIC -std=c++2b
+
 all:
-	$(CXX) -shared -fPIC $(EXTRA_FLAGS) main.cpp borderDeco.cpp BorderppPassElement.cpp -o borders-plus-plus.so -g `pkg-config --cflags pixman-1 libdrm hyprland pangocairo libinput libudev wayland-server xkbcommon` -std=c++2b -O2
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(EXTRA_FLAGS) main.cpp borderDeco.cpp BorderppPassElement.cpp -o borders-plus-plus.so `pkg-config --cflags pixman-1 libdrm hyprland pangocairo libinput libudev wayland-server xkbcommon`
 
 clean:
 	rm ./borders-plus-plus.so

--- a/csgo-vulkan-fix/Makefile
+++ b/csgo-vulkan-fix/Makefile
@@ -5,7 +5,10 @@ else
     EXTRA_FLAGS =
 endif
 
+CXXFLAGS ?= -O2
+CXXFLAGS += -shared -fPIC -std=c++2b
+
 all:
-	$(CXX) -shared -fPIC $(EXTRA_FLAGS) main.cpp -o csgo-vulkan-fix.so -g `pkg-config --cflags pixman-1 libdrm hyprland pangocairo libinput libudev wayland-server xkbcommon` -std=c++2b -O2
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(EXTRA_FLAGS) main.cpp -o csgo-vulkan-fix.so `pkg-config --cflags pixman-1 libdrm hyprland pangocairo libinput libudev wayland-server xkbcommon`
 clean:
 	rm ./csgo-vulkan-fix.so

--- a/hyprbars/Makefile
+++ b/hyprbars/Makefile
@@ -5,7 +5,8 @@ else
     EXTRA_FLAGS =
 endif
 
-CXXFLAGS = -shared -fPIC -g -std=c++2b -Wno-c++11-narrowing
+CXXFLAGS ?= -O2
+CXXFLAGS += -shared -fPIC -std=c++2b -Wno-c++11-narrowing
 INCLUDES = `pkg-config --cflags pixman-1 libdrm hyprland pangocairo libinput libudev wayland-server xkbcommon`
 LIBS = `pkg-config --libs pangocairo`
 
@@ -15,7 +16,7 @@ TARGET = hyprbars.so
 all: $(TARGET)
 
 $(TARGET): $(SRC)
-	$(CXX) $(CXXFLAGS) $(EXTRA_FLAGS) $(INCLUDES) $^ $> -o $@ $(LIBS) -O2
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(EXTRA_FLAGS) $(INCLUDES) $^ $> -o $@ $(LIBS)
 
 clean:
 	rm ./$(TARGET)

--- a/hyprexpo/Makefile
+++ b/hyprexpo/Makefile
@@ -5,7 +5,10 @@ else
     EXTRA_FLAGS =
 endif
 
+CXXFLAGS ?= -O2
+CXXFLAGS += -shared -fPIC -std=c++2b -Wno-narrowing
+
 all:
-	$(CXX) -shared -fPIC $(EXTRA_FLAGS) main.cpp overview.cpp ExpoGesture.cpp OverviewPassElement.cpp -o hyprexpo.so -g `pkg-config --cflags pixman-1 libdrm hyprland pangocairo libinput libudev wayland-server xkbcommon` -std=c++2b -Wno-narrowing
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(EXTRA_FLAGS) main.cpp overview.cpp ExpoGesture.cpp OverviewPassElement.cpp -o hyprexpo.so `pkg-config --cflags pixman-1 libdrm hyprland pangocairo libinput libudev wayland-server xkbcommon`
 clean:
 	rm ./hyprexpo.so

--- a/hyprfocus/Makefile
+++ b/hyprfocus/Makefile
@@ -5,7 +5,10 @@ else
     EXTRA_FLAGS =
 endif
 
+CXXFLAGS ?= -O2
+CXXFLAGS += -shared -fPIC -std=c++2b
+
 all:
-	$(CXX) -shared -fPIC $(EXTRA_FLAGS) main.cpp -o hyprfocus.so -g `pkg-config --cflags pixman-1 libdrm hyprland pangocairo libinput libudev wayland-server xkbcommon` -std=c++2b -O2
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(EXTRA_FLAGS) main.cpp -o hyprfocus.so `pkg-config --cflags pixman-1 libdrm hyprland pangocairo libinput libudev wayland-server xkbcommon`
 clean:
 	rm ./hyprfocus.so

--- a/hyprscrolling/Makefile
+++ b/hyprscrolling/Makefile
@@ -5,8 +5,10 @@ else
     EXTRA_FLAGS =
 endif
 
+CXXFLAGS ?= -O2
+CXXFLAGS += -shared -fPIC -std=c++2b
 
 all:
-	$(CXX) -shared -fPIC $(EXTRA_FLAGS) main.cpp Scrolling.cpp -o hyprscrolling.so -g `pkg-config --cflags pixman-1 libdrm hyprland pangocairo libinput libudev wayland-server xkbcommon` -std=c++2b
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(EXTRA_FLAGS) main.cpp Scrolling.cpp -o hyprscrolling.so `pkg-config --cflags pixman-1 libdrm hyprland pangocairo libinput libudev wayland-server xkbcommon`
 clean:
 	rm ./hyprscrolling.so

--- a/hyprtrails/Makefile
+++ b/hyprtrails/Makefile
@@ -5,7 +5,10 @@ else
     EXTRA_FLAGS =
 endif
 
+CXXFLAGS ?= -O2
+CXXFLAGS += -shared -fPIC -std=c++2b
+
 all:
-	$(CXX) -shared -fPIC $(EXTRA_FLAGS) main.cpp trail.cpp TrailPassElement.cpp -o hyprtrails.so -g `pkg-config --cflags pixman-1 libdrm hyprland pangocairo libinput libudev wayland-server xkbcommon` -std=c++2b -O2
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(EXTRA_FLAGS) main.cpp trail.cpp TrailPassElement.cpp -o hyprtrails.so `pkg-config --cflags pixman-1 libdrm hyprland pangocairo libinput libudev wayland-server xkbcommon`
 clean:
 	rm ./hyprtrails.so

--- a/hyprwinwrap/Makefile
+++ b/hyprwinwrap/Makefile
@@ -5,7 +5,10 @@ else
     EXTRA_FLAGS =
 endif
 
+CXXFLAGS ?= -O2
+CXXFLAGS += -shared -fPIC -std=c++2b
+
 all:
-	$(CXX) -shared -fPIC $(EXTRA_FLAGS) main.cpp -o hyprwinwrap.so -g `pkg-config --cflags pixman-1 libdrm hyprland pangocairo libinput libudev wayland-server xkbcommon` -std=c++2b -O2
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(EXTRA_FLAGS) main.cpp -o hyprwinwrap.so `pkg-config --cflags pixman-1 libdrm hyprland pangocairo libinput libudev wayland-server xkbcommon`
 clean:
 	rm ./hyprwinwrap.so

--- a/xtra-dispatchers/Makefile
+++ b/xtra-dispatchers/Makefile
@@ -5,7 +5,10 @@ else
     EXTRA_FLAGS =
 endif
 
+CXXFLAGS ?= -O2
+CXXFLAGS += -shared -fPIC -std=c++2b
+
 all:
-	$(CXX) -shared -fPIC $(EXTRA_FLAGS) main.cpp -o xtra-dispatchers.so -g `pkg-config --cflags pixman-1 libdrm hyprland pangocairo libinput libudev wayland-server xkbcommon` -std=c++2b -O2
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(EXTRA_FLAGS) main.cpp -o xtra-dispatchers.so `pkg-config --cflags pixman-1 libdrm hyprland pangocairo libinput libudev wayland-server xkbcommon`
 clean:
 	rm ./xtra-dispatchers.so


### PR DESCRIPTION
I have a patch for hyprpm that sets custom values for env variables `CXX` and `CXXFLAGS` and `LDFLAGS`, but the current Makefiles stubbornly make their own. This PR makes `-O2` the default (will be absent if not specified to prevent conflicts with specifying `-O3`), removes `-g` (as it doesn't seem to be useful other than occupy space, but am happy to revert this), then appends the remaining `-shared -fPIC -std=c++2b` and any warning flags.