### PR TITLE
Add button hover effect and inactive bar color support

### DIFF
--- a/hyprbars/main.cpp
+++ b/hyprbars/main.cpp
@@ -133,6 +133,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
                                                           [&](void* self, SCallbackInfo& info, std::any data) { onUpdateWindowRules(std::any_cast<PHLWINDOW>(data)); });
 
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_color", Hyprlang::INT{*configStringToInt("rgba(33333388)")});
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_color_inactive", Hyprlang::INT{0}); // unset by default, uses bar_color if not set
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_height", Hyprlang::INT{15});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:col.text", Hyprlang::INT{*configStringToInt("rgba(ffffffff)")});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_text_size", Hyprlang::INT{10});
@@ -148,6 +149,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:enabled", Hyprlang::INT{1});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:icon_on_hover", Hyprlang::INT{0});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:inactive_button_color", Hyprlang::INT{0}); // unset
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:button_hover_bg_color", Hyprlang::INT{*configStringToInt("rgba(ffffff11)")}); // subtle white hover
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:on_double_click", Hyprlang::STRING{""});
 
     HyprlandAPI::addConfigKeyword(PHANDLE, "plugin:hyprbars:hyprbars-button", onNewButton, Hyprlang::SHandlerOptions{});


### PR DESCRIPTION
This commit adds two new features to hyprbars:

1. Button hover background effect:
   - Added `button_hover_bg_color` config option for Windows 11-style hover effect
   - Hover rectangles are properly centered on button icons
   - Close button (rightmost) extends to window edge
   - All buttons include half padding on each side for even spacing
   - Hover effect scales with bar_button_padding setting

2. Separate bar colors for active/inactive windows:
   - Added `bar_color_inactive` config option
   - Bar color now changes based on window focus state
   - Matches Hyprland's border behavior (active/inactive)
   - Smooth animated transition between colors
   - Falls back to `bar_color` if `bar_color_inactive` is not set

Config example:
  plugin:hyprbars:button_hover_bg_color = rgba(ffffff22)
  plugin:hyprbars:bar_color = rgba(33333388)
  plugin:hyprbars:bar_color_inactive = rgba(2E2E32FF)