### PR TITLE
Change stdenv.hostPlatform.system because "system" is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ this:
     enable = true;
     # ...
     plugins = [
-      inputs.hyprland-plugins.packages.${pkgs.system}.hyprbars
+      inputs.hyprland-plugins.packages.${pkgs.stdenv.hostPlatform.system}.hyprbars
       # ...
     ];
   };
@@ -84,7 +84,7 @@ If you don't use Home Manager:
 ```nix
 { lib, pkgs, inputs, ... }:
 with lib; let
-  hyprPluginPkgs = inputs.hyprland-plugins.packages.${pkgs.system};
+  hyprPluginPkgs = inputs.hyprland-plugins.packages.${pkgs.stdenv.hostPlatform.system};
   hypr-plugin-dir = pkgs.symlinkJoin {
     name = "hyrpland-plugins";
     paths = with hyprPluginPkgs; [


### PR DESCRIPTION
Tiny thing but might as well be accurate since it's already changed on the wiki