### PR TITLE
hyprexpo: add bring mode for visual expo selection

### DIFF
--- a/hyprexpo/README.md
+++ b/hyprexpo/README.md
@@ -53,8 +53,8 @@ Here are a list of options you can use:
 | --- | --- |
 toggle | displays if hidden, hide if displayed
 select | selects the hovered desktop
+bring | brings a window from the hovered desktop to the current desktop
 off | hides the overview
 disable | same as `off`
 on | displays the overview
 enable | same as `on`
-

--- a/hyprexpo/main.cpp
+++ b/hyprexpo/main.cpp
@@ -67,6 +67,47 @@ static void hkAddDamageB(void* thisptr, const pixman_region32_t* rg) {
     g_pOverview->onDamageReported();
 }
 
+static PHLWINDOW windowToBringFromWorkspace(const PHLWORKSPACE& workspace) {
+    if (!workspace)
+        return nullptr;
+
+    for (auto it = g_pCompositor->m_windows.rbegin(); it != g_pCompositor->m_windows.rend(); ++it) {
+        const auto& w = *it;
+        if (!w || w->m_workspace != workspace || !w->m_isMapped || w->isHidden())
+            continue;
+
+        return w;
+    }
+
+    return nullptr;
+}
+
+static SDispatchResult bringWindowFromWorkspace(int64_t sourceWorkspaceID) {
+    if (sourceWorkspaceID == WORKSPACE_INVALID)
+        return {.success = false, .error = "selected workspace is empty"};
+
+    const auto FOCUSSTATE = Desktop::focusState();
+    const auto MONITOR    = FOCUSSTATE->monitor();
+    if (!MONITOR || !MONITOR->m_activeWorkspace)
+        return {.success = false, .error = "no active monitor/workspace"};
+
+    if (sourceWorkspaceID == MONITOR->activeWorkspaceID())
+        return {};
+
+    const auto SOURCEWORKSPACE = g_pCompositor->getWorkspaceByID(sourceWorkspaceID);
+    if (!SOURCEWORKSPACE)
+        return {.success = false, .error = "selected workspace is not open"};
+
+    const auto WINDOW = windowToBringFromWorkspace(SOURCEWORKSPACE);
+    if (!WINDOW)
+        return {.success = false, .error = "selected workspace has no mapped windows"};
+
+    g_pCompositor->moveWindowToWorkspaceSafe(WINDOW, MONITOR->m_activeWorkspace);
+    FOCUSSTATE->fullWindowFocus(WINDOW);
+    g_pCompositor->warpCursorTo(WINDOW->middle());
+    return {};
+}
+
 static SDispatchResult onExpoDispatcher(std::string arg) {
 
     if (g_pOverview && g_pOverview->m_isSwiping)
@@ -76,6 +117,15 @@ static SDispatchResult onExpoDispatcher(std::string arg) {
         if (g_pOverview) {
             g_pOverview->selectHoveredWorkspace();
             g_pOverview->close();
+        }
+        return {};
+    }
+    if (arg == "bring") {
+        if (g_pOverview) {
+            g_pOverview->selectHoveredWorkspace();
+            const auto BRINGRESULT = bringWindowFromWorkspace(g_pOverview->selectedWorkspaceID());
+            g_pOverview->close(false);
+            return BRINGRESULT;
         }
         return {};
     }

--- a/hyprexpo/overview.cpp
+++ b/hyprexpo/overview.cpp
@@ -246,6 +246,14 @@ void COverview::selectHoveredWorkspace() {
     closeOnID = x + y * SIDE_LENGTH;
 }
 
+int64_t COverview::selectedWorkspaceID() const {
+    const int ID = closeOnID == -1 ? openedID : closeOnID;
+    if (ID < 0 || ID >= (int)images.size())
+        return WORKSPACE_INVALID;
+
+    return images[ID].workspaceID;
+}
+
 void COverview::redrawID(int id, bool forcelowres) {
     if (!pMonitor)
         return;
@@ -354,7 +362,7 @@ void COverview::onDamageReported() {
     g_pCompositor->scheduleFrameForMonitor(pMonitor.lock());
 }
 
-void COverview::close() {
+void COverview::close(bool switchToSelection) {
     if (closing)
         return;
 
@@ -374,7 +382,7 @@ void COverview::close() {
 
     redrawAll();
 
-    if (TILE.workspaceID != pMonitor->activeWorkspaceID()) {
+    if (switchToSelection && TILE.workspaceID != pMonitor->activeWorkspaceID()) {
         pMonitor->setSpecialWorkspace(0);
 
         // If this tile's workspace was WORKSPACE_INVALID, move to the next

--- a/hyprexpo/overview.hpp
+++ b/hyprexpo/overview.hpp
@@ -32,8 +32,9 @@ class COverview {
     void onSwipeEnd();
 
     // close without a selection
-    void          close();
+    void          close(bool switchToSelection = true);
     void          selectHoveredWorkspace();
+    int64_t       selectedWorkspaceID() const;
 
     bool          blockOverviewRendering = false;
     bool          blockDamageReporting   = false;


### PR DESCRIPTION
## Summary
- add a new `bring` option to `hyprexpo:expo`
- selecting a tile in `bring` mode moves one mapped window from the hovered workspace to the current workspace
- keep overview close animation but skip workspace switching in bring mode
- document the new dispatcher option in the hyprexpo README

## Behavior
- `bind = MOD, KEY, hyprexpo:expo, bring`
- selecting your current workspace is a no-op
- selecting a tile without a mapped window returns a dispatcher error

## Validation
- `nix shell nixpkgs#clang-tools --command bash -lc 'clang-format -i hyprexpo/main.cpp hyprexpo/overview.cpp hyprexpo/overview.hpp'`
- `nix build .#hyprexpo`
- `nix flake check -L --keep-going`
