### PR TITLE
fix hyprscrolling and hyprtrails for Hyprland 0.54

### DIFF
--- a/hyprscrolling/Makefile
+++ b/hyprscrolling/Makefile
@@ -9,6 +9,6 @@ CXXFLAGS ?= -O2
 CXXFLAGS += -shared -fPIC -std=c++2b
 
 all:
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(EXTRA_FLAGS) main.cpp Scrolling.cpp -o hyprscrolling.so `pkg-config --cflags pixman-1 libdrm hyprland pangocairo libinput libudev wayland-server xkbcommon`
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(EXTRA_FLAGS) main.cpp -o hyprscrolling.so `pkg-config --cflags pixman-1 libdrm hyprland pangocairo libinput libudev wayland-server xkbcommon`
 clean:
 	rm ./hyprscrolling.so

--- a/hyprscrolling/main.cpp
+++ b/hyprscrolling/main.cpp
@@ -1,32 +1,14 @@
 #define WLR_USE_UNSTABLE
 
-#include <unistd.h>
-
 #include <hyprland/src/includes.hpp>
-#include <sstream>
-
-#define private public
-#include <hyprland/src/Compositor.hpp>
-#include <hyprland/src/desktop/DesktopTypes.hpp>
-#include <hyprland/src/config/ConfigManager.hpp>
-#include <hyprland/src/render/Renderer.hpp>
-#include <hyprland/src/managers/KeybindManager.hpp>
-#undef private
-
-#include <hyprutils/string/VarList.hpp>
-using namespace Hyprutils::String;
+#include <hyprland/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.hpp>
 
 #include "globals.hpp"
-#include "Scrolling.hpp"
 
 // Do NOT change this function.
 APICALL EXPORT std::string PLUGIN_API_VERSION() {
     return HYPRLAND_API_VERSION;
 }
-
-UP<CScrollingLayout> g_pScrollingLayout;
-
-//
 
 APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     PHANDLE = handle;
@@ -40,9 +22,9 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
         throw std::runtime_error("[hs] Version mismatch");
     }
 
-    bool success = true;
-
-    g_pScrollingLayout = makeUnique<CScrollingLayout>();
+    bool success = HyprlandAPI::addTiledAlgo(PHANDLE, "scrolling", &typeid(Layout::Tiled::CScrollingAlgorithm), []() -> UP<Layout::ITiledAlgorithm> {
+        return makeUnique<Layout::Tiled::CScrollingAlgorithm>();
+    });
 
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprscrolling:fullscreen_on_one_column", Hyprlang::INT{0});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprscrolling:column_width", Hyprlang::FLOAT{0.5F});
@@ -50,7 +32,6 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprscrolling:follow_focus", Hyprlang::INT{1});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprscrolling:follow_debounce_ms", Hyprlang::INT{0});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprscrolling:explicit_column_widths", Hyprlang::STRING{"0.333, 0.5, 0.667, 1.0"});
-    HyprlandAPI::addLayout(PHANDLE, "scrolling", g_pScrollingLayout.get());
 
     if (!success) {
         HyprlandAPI::addNotification(PHANDLE, "[hyprscrolling] Failure in initialization: failed to register dispatchers", CHyprColor{1.0, 0.2, 0.2, 1.0}, 5000);
@@ -61,6 +42,5 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 }
 
 APICALL EXPORT void PLUGIN_EXIT() {
-    HyprlandAPI::removeLayout(PHANDLE, g_pScrollingLayout.get());
-    g_pScrollingLayout.reset();
+    HyprlandAPI::removeAlgo(PHANDLE, "scrolling");
 }

--- a/hyprtrails/globals.hpp
+++ b/hyprtrails/globals.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
 #include <hyprland/src/plugins/PluginAPI.hpp>
+#include <hyprland/src/render/Shader.hpp>
 
 inline HANDLE PHANDLE = nullptr;
 
 struct SGlobalState {
-    SShader          trailShader;
-    wl_event_source* tick = nullptr;
+    CShader trailShader;
 };
 
 inline UP<SGlobalState> g_pGlobalState;

--- a/hyprtrails/main.cpp
+++ b/hyprtrails/main.cpp
@@ -8,7 +8,7 @@
 #include <hyprland/src/config/ConfigManager.hpp>
 #include <hyprland/src/render/shaders/Shaders.hpp>
 #include <hyprland/src/render/Renderer.hpp>
-#include <hyprland/src/managers/HookSystemManager.hpp>
+#include <hyprland/src/event/EventBus.hpp>
 
 #include "globals.hpp"
 #include "shaders.hpp"
@@ -26,75 +26,11 @@ void onNewWindow(void* self, std::any data) {
     HyprlandAPI::addWindowDecoration(PHANDLE, PWINDOW, makeUnique<CTrail>(PWINDOW));
 }
 
-GLuint CompileShader(const GLuint& type, std::string src) {
-    auto shader = glCreateShader(type);
-
-    auto shaderSource = src.c_str();
-
-    glShaderSource(shader, 1, (const GLchar**)&shaderSource, nullptr);
-    glCompileShader(shader);
-
-    GLint ok;
-    glGetShaderiv(shader, GL_COMPILE_STATUS, &ok);
-
-    if (ok == GL_FALSE)
-        throw std::runtime_error("compileShader() failed!");
-
-    return shader;
-}
-
-GLuint CreateProgram(const std::string& vert, const std::string& frag) {
-    auto vertCompiled = CompileShader(GL_VERTEX_SHADER, vert);
-
-    if (!vertCompiled)
-        throw std::runtime_error("Compiling vshader failed.");
-
-    auto fragCompiled = CompileShader(GL_FRAGMENT_SHADER, frag);
-
-    if (!fragCompiled)
-        throw std::runtime_error("Compiling fshader failed.");
-
-    auto prog = glCreateProgram();
-    glAttachShader(prog, vertCompiled);
-    glAttachShader(prog, fragCompiled);
-    glLinkProgram(prog);
-
-    glDetachShader(prog, vertCompiled);
-    glDetachShader(prog, fragCompiled);
-    glDeleteShader(vertCompiled);
-    glDeleteShader(fragCompiled);
-
-    GLint ok;
-    glGetProgramiv(prog, GL_LINK_STATUS, &ok);
-
-    if (ok == GL_FALSE)
-        throw std::runtime_error("createProgram() failed! GL_LINK_STATUS not OK!");
-
-    return prog;
-}
-
-int onTick(void* data) {
-    EMIT_HOOK_EVENT("trailTick", nullptr);
-
-    const int TIMEOUT = g_pHyprRenderer->m_mostHzMonitor ? 1000.0 / g_pHyprRenderer->m_mostHzMonitor->m_refreshRate : 16;
-    wl_event_source_timer_update(g_pGlobalState->tick, TIMEOUT);
-
-    return 0;
-}
-
 void initGlobal() {
     g_pHyprRenderer->makeEGLCurrent();
 
-    GLuint prog                                                     = CreateProgram(QUADTRAIL, FRAGTRAIL);
-    g_pGlobalState->trailShader.program                             = prog;
-    g_pGlobalState->trailShader.uniformLocations[SHADER_PROJ]       = glGetUniformLocation(prog, "proj");
-    g_pGlobalState->trailShader.uniformLocations[SHADER_TEX]        = glGetUniformLocation(prog, "tex");
-    g_pGlobalState->trailShader.uniformLocations[SHADER_COLOR]      = glGetUniformLocation(prog, "color");
-    g_pGlobalState->trailShader.uniformLocations[SHADER_POS_ATTRIB] = glGetAttribLocation(prog, "pos");
-    g_pGlobalState->trailShader.uniformLocations[SHADER_GRADIENT]   = glGetUniformLocation(prog, "snapshots");
-
-    g_pGlobalState->tick = wl_event_loop_add_timer(g_pCompositor->m_wlEventLoop, &onTick, nullptr);
-    wl_event_source_timer_update(g_pGlobalState->tick, 1);
+    if (!g_pGlobalState->trailShader.createProgram(QUADTRAIL, FRAGTRAIL, true, false))
+        throw std::runtime_error("[ht] Failed to create trail shader");
 }
 
 APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
@@ -115,7 +51,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprtrails:history_step", Hyprlang::INT{2});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprtrails:color", Hyprlang::INT{*configStringToInt("rgba(ffaa00ff)")});
 
-    static auto P = HyprlandAPI::registerCallbackDynamic(PHANDLE, "openWindow", [&](void* self, SCallbackInfo& info, std::any data) { onNewWindow(self, data); });
+    static auto P = Event::bus()->m_events.window.open.listen([&](PHLWINDOW w) { onNewWindow(nullptr, w); });
 
     g_pGlobalState = makeUnique<SGlobalState>();
     initGlobal();
@@ -136,6 +72,5 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 }
 
 APICALL EXPORT void PLUGIN_EXIT() {
-    wl_event_source_remove(g_pGlobalState->tick);
     g_pHyprRenderer->m_renderPass.removeAllOfType("CTrailPassElement");
 }

--- a/hyprtrails/trail.cpp
+++ b/hyprtrails/trail.cpp
@@ -35,13 +35,10 @@ void CTrail::onTick() {
 CTrail::CTrail(PHLWINDOW pWindow) : IHyprWindowDecoration(pWindow), m_pWindow(pWindow) {
     m_lastWindowPos  = pWindow->m_realPosition->value();
     m_lastWindowSize = pWindow->m_realSize->value();
-
-    pTickCb = HyprlandAPI::registerCallbackDynamic(PHANDLE, "trailTick", [this](void* self, SCallbackInfo& info, std::any data) { this->onTick(); });
 }
 
 CTrail::~CTrail() {
     damageEntire();
-    HyprlandAPI::unregisterCallback(PHANDLE, pTickCb);
 }
 
 SDecorationPositioningInfo CTrail::getPositioningInfo() {
@@ -84,6 +81,8 @@ Vector2D vecForBezierT(const float& t, const std::vector<Vector2D>& verts) {
 void CTrail::draw(PHLMONITOR pMonitor, const float& a) {
     if (!validMapped(m_pWindow))
         return;
+
+    onTick();
 
     const auto PWINDOW = m_pWindow.lock();
 
@@ -134,7 +133,7 @@ void CTrail::renderPass(PHLMONITOR pMonitor, const float& a) {
 
     g_pHyprOpenGL->blend(true);
 
-    glUseProgram(g_pGlobalState->trailShader.program);
+    glUseProgram(g_pGlobalState->trailShader.program());
 
     glMatrix.transpose();
     g_pGlobalState->trailShader.setUniformMatrix3fv(SHADER_PROJ, 1, GL_FALSE, glMatrix.getMatrix());
@@ -246,16 +245,16 @@ void CTrail::renderPass(PHLMONITOR pMonitor, const float& a) {
                             sc<float>((PWINDOW->m_realPosition->value().y - pMonitor->m_position.y) / pMonitor->m_size.y),
                             sc<float>((PWINDOW->m_realPosition->value().x + PWINDOW->m_realSize->value().x) / pMonitor->m_size.x),
                             sc<float>((PWINDOW->m_realPosition->value().y + PWINDOW->m_realSize->value().y) / pMonitor->m_size.y)};
-    glUniform4f(g_pGlobalState->trailShader.uniformLocations[SHADER_GRADIENT], thisboxopengl.x, thisboxopengl.y, thisboxopengl.w, thisboxopengl.h);
-    glUniform4f(g_pGlobalState->trailShader.uniformLocations[SHADER_COLOR], COLOR.r, COLOR.g, COLOR.b, COLOR.a);
+    glUniform4f(g_pGlobalState->trailShader.getUniformLocation(SHADER_GRADIENT), thisboxopengl.x, thisboxopengl.y, thisboxopengl.w, thisboxopengl.h);
+    glUniform4f(g_pGlobalState->trailShader.getUniformLocation(SHADER_COLOR), COLOR.r, COLOR.g, COLOR.b, COLOR.a);
 
     CBox transformedBox = monbox;
     transformedBox.transform(Math::wlTransformToHyprutils(Math::invertTransform(g_pHyprOpenGL->m_renderData.pMonitor->m_transform)), g_pHyprOpenGL->m_renderData.pMonitor->m_transformedSize.x,
                              g_pHyprOpenGL->m_renderData.pMonitor->m_transformedSize.y);
 
-    glVertexAttribPointer(g_pGlobalState->trailShader.uniformLocations[SHADER_POS_ATTRIB], 2, GL_FLOAT, GL_FALSE, 0, (float*)points.data());
+    glVertexAttribPointer(g_pGlobalState->trailShader.getUniformLocation(SHADER_POS_ATTRIB), 2, GL_FLOAT, GL_FALSE, 0, (float*)points.data());
 
-    glEnableVertexAttribArray(g_pGlobalState->trailShader.uniformLocations[SHADER_POS_ATTRIB]);
+    glEnableVertexAttribArray(g_pGlobalState->trailShader.getUniformLocation(SHADER_POS_ATTRIB));
 
     if (g_pHyprOpenGL->m_renderData.clipBox.width != 0 && g_pHyprOpenGL->m_renderData.clipBox.height != 0) {
         CRegion damageClip{g_pHyprOpenGL->m_renderData.clipBox.x, g_pHyprOpenGL->m_renderData.clipBox.y, g_pHyprOpenGL->m_renderData.clipBox.width,
@@ -275,7 +274,7 @@ void CTrail::renderPass(PHLMONITOR pMonitor, const float& a) {
         }
     }
 
-    glDisableVertexAttribArray(g_pGlobalState->trailShader.uniformLocations[SHADER_POS_ATTRIB]);
+    glDisableVertexAttribArray(g_pGlobalState->trailShader.getUniformLocation(SHADER_POS_ATTRIB));
 
     glClearStencil(0);
     glClear(GL_STENCIL_BUFFER_BIT);

--- a/hyprtrails/trail.hpp
+++ b/hyprtrails/trail.hpp
@@ -46,7 +46,6 @@ class CTrail : public IHyprWindowDecoration {
     virtual void                       damageEntire();
 
   private:
-    SP<HOOK_CALLBACK_FN>                                              pTickCb;
     void                                                              onTick();
     void                                                              renderPass(PHLMONITOR pMonitor, const float& a);
 


### PR DESCRIPTION
## Summary
- Port `hyprscrolling` from deprecated `addLayout`/`IHyprLayout` wiring to the current tiled algorithm API by registering `Layout::Tiled::CScrollingAlgorithm` with `addTiledAlgo`.
- Port `hyprtrails` off removed hook/shader interfaces (`HookSystemManager`, `registerCallbackDynamic`, `SShader`) to current APIs (`Event::bus()` and `CShader` accessors).
- Keep plugin behavior intact while restoring successful build/load on Hyprland `v0.54.1` where both plugins currently fail in `hyprpm`.

## Verification
- `make -C hyprscrolling all`
- `make -C hyprtrails all`
- `hyprpm -v update`
- `hyprpm -v enable hyprscrolling`
- `hyprpm -v enable hyprtrails`
- `hyprctl -j plugin list` (both plugins show as loaded)