### PR TITLE
hyprbars: add bar_inactive_color config option

### DIFF
--- a/hyprbars/barDeco.cpp
+++ b/hyprbars/barDeco.cpp
@@ -599,7 +599,7 @@ void CHyprBar::renderPass(PHLMONITOR pMonitor, const float& a) {
     }
 
     CHyprColor DEST_COLOR;
-    if (**PINACTIVEBARCOLOR > 0 && !m_bWindowHasFocus)
+    if (**PINACTIVEBARCOLOR != -1 && !m_bWindowHasFocus)
         DEST_COLOR = CHyprColor(**PINACTIVEBARCOLOR);
     else
         DEST_COLOR = m_bForcedBarColor.value_or(**PCOLOR);

--- a/hyprbars/barDeco.cpp
+++ b/hyprbars/barDeco.cpp
@@ -588,8 +588,9 @@ void CHyprBar::renderPass(PHLMONITOR pMonitor, const float& a) {
     static auto* const PENABLEBLUR       = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_blur")->getDataStaticPtr();
     static auto* const PENABLEBLURGLOBAL = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "decoration:blur:enabled")->getDataStaticPtr();
     static auto* const PINACTIVECOLOR    = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:inactive_button_color")->getDataStaticPtr();
+    static auto* const PINACTIVEBARCOLOR = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_inactive_color")->getDataStaticPtr();
 
-    if (**PINACTIVECOLOR > 0) {
+    {
         bool currentWindowFocus = PWINDOW == Desktop::focusState()->window();
         if (currentWindowFocus != m_bWindowHasFocus) {
             m_bWindowHasFocus = currentWindowFocus;
@@ -597,7 +598,11 @@ void CHyprBar::renderPass(PHLMONITOR pMonitor, const float& a) {
         }
     }
 
-    const CHyprColor DEST_COLOR = m_bForcedBarColor.value_or(**PCOLOR);
+    CHyprColor DEST_COLOR;
+    if (**PINACTIVEBARCOLOR > 0 && !m_bWindowHasFocus)
+        DEST_COLOR = CHyprColor(**PINACTIVEBARCOLOR);
+    else
+        DEST_COLOR = m_bForcedBarColor.value_or(**PCOLOR);
     if (DEST_COLOR != m_cRealBarColor->goal())
         *m_cRealBarColor = DEST_COLOR;
 

--- a/hyprbars/main.cpp
+++ b/hyprbars/main.cpp
@@ -131,6 +131,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:enabled", Hyprlang::INT{1});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:icon_on_hover", Hyprlang::INT{0});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:inactive_button_color", Hyprlang::INT{0}); // unset
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_inactive_color", Hyprlang::INT{0});  // unset
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:on_double_click", Hyprlang::STRING{""});
 
     HyprlandAPI::addConfigKeyword(PHANDLE, "plugin:hyprbars:hyprbars-button", onNewButton, Hyprlang::SHandlerOptions{});

--- a/hyprbars/main.cpp
+++ b/hyprbars/main.cpp
@@ -131,7 +131,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:enabled", Hyprlang::INT{1});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:icon_on_hover", Hyprlang::INT{0});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:inactive_button_color", Hyprlang::INT{0}); // unset
-    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_inactive_color", Hyprlang::INT{0});  // unset
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_inactive_color", Hyprlang::INT{-1}); // unset
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:on_double_click", Hyprlang::STRING{""});
 
     HyprlandAPI::addConfigKeyword(PHANDLE, "plugin:hyprbars:hyprbars-button", onNewButton, Hyprlang::SHandlerOptions{});


### PR DESCRIPTION
Adds a `bar_inactive_color` config option, allowing a different bar background color for inactive windows. This complements the existing `inactive_button_color` option.

The focus tracking logic now runs unconditionally (instead of only when `inactive_button_color` is set) so both features work independently. The default sentinel uses `-1` instead of `0` to allow fully transparent colors like `rgba(00000000)`.

## Usage

```ini
plugin:hyprbars {
    bar_color = rgba(ff0000ff)
    bar_inactive_color = rgba(414868ff)
}
```

When unset (default), inactive windows use the regular `bar_color`.

## Demo

https://github.com/user-attachments/assets/0cdf489a-8430-44a9-a4ce-8e5c933c8781
