### PR TITLE
hyprwinwrap fix: overlay render after special workspace

### DIFF
--- a/hyprwinwrap/main.cpp
+++ b/hyprwinwrap/main.cpp
@@ -115,7 +115,7 @@ void onCloseWindow(PHLWINDOW pWindow) {
 }
 
 void onRenderStage(eRenderStage stage) {
-    if (stage != RENDER_PRE_WINDOWS)
+    if (stage != RENDER_POST_WALLPAPER)
         return;
 
     for (auto& bg : bgWindows) {


### PR DESCRIPTION
Bug: window rendered on top some seconds after closing special workspace

***

Before:

https://github.com/user-attachments/assets/3db62c60-aab9-455f-b75d-4cd802327321

After:

https://github.com/user-attachments/assets/bd94f7a2-b6fc-4093-afb6-5938ea45b08c

***

Note: _In video, Im using a solid color wallpaper (not a lack of wallpaper). The fix works exactly the same with any image or pattern:_

<img width="2560" height="1402" alt="image" src="https://github.com/user-attachments/assets/32b6f57b-d14a-4b5c-9d28-6dc17403c8a0" />
