### PR TITLE
hyprbars: inactive window bar and text colour support

### DIFF
--- a/hyprbars/README.md
+++ b/hyprbars/README.md
@@ -43,6 +43,8 @@ plugin {
 `bar_button_padding` | int | padding between the buttons | `5`
 `icon_on_hover` | bool | whether the icons show on mouse hovering over the buttons | `false`
 `inactive_button_color` | col | buttons bg color when window isn't focused
+`bar_inactive_color` | color | bar's background color when window isn't focused  |  use `bar_color`
+`col.inactive_text` | color | bar's title text color when window isn't focused |  use `col.text`
 `on_double_click` | str | command to run on double click of the bar (not on a button)
 
 ## Buttons Config

--- a/hyprbars/barDeco.cpp
+++ b/hyprbars/barDeco.cpp
@@ -341,13 +341,14 @@ void CHyprBar::renderText(SP<CTexture> out, const std::string& text, const CHypr
 }
 
 void CHyprBar::renderBarTitle(const Vector2D& bufferSize, const float scale) {
-    static auto* const PCOLOR            = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:col.text")->getDataStaticPtr();
-    static auto* const PSIZE             = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_text_size")->getDataStaticPtr();
-    static auto* const PFONT             = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_text_font")->getDataStaticPtr();
-    static auto* const PALIGN            = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_text_align")->getDataStaticPtr();
-    static auto* const PALIGNBUTTONS     = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_buttons_alignment")->getDataStaticPtr();
-    static auto* const PBARPADDING       = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_padding")->getDataStaticPtr();
-    static auto* const PBARBUTTONPADDING = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_button_padding")->getDataStaticPtr();
+    static auto* const PCOLOR             = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:col.text")->getDataStaticPtr();
+    static auto* const PSIZE              = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_text_size")->getDataStaticPtr();
+    static auto* const PFONT              = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_text_font")->getDataStaticPtr();
+    static auto* const PALIGN             = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_text_align")->getDataStaticPtr();
+    static auto* const PALIGNBUTTONS      = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_buttons_alignment")->getDataStaticPtr();
+    static auto* const PBARPADDING        = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_padding")->getDataStaticPtr();
+    static auto* const PBARBUTTONPADDING  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_button_padding")->getDataStaticPtr();
+    static auto* const PTEXTINACTIVECOLOR = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:col.inactive_text")->getDataStaticPtr();
 
     const bool         BUTTONSRIGHT = std::string{*PALIGNBUTTONS} != "left";
 
@@ -366,7 +367,8 @@ void CHyprBar::renderBarTitle(const Vector2D& bufferSize, const float scale) {
     const auto       scaledButtonsPad  = **PBARBUTTONPADDING * scale;
     const auto       scaledBarPadding  = **PBARPADDING * scale;
 
-    const CHyprColor COLOR = m_bForcedTitleColor.value_or(**PCOLOR);
+    const CHyprColor ACTIVE_TEXT_COLOR = m_bForcedTitleColor.value_or(**PCOLOR);
+    const CHyprColor COLOR             = (!m_bWindowHasFocus && **PTEXTINACTIVECOLOR > 0) ? CHyprColor(**PTEXTINACTIVECOLOR) : ACTIVE_TEXT_COLOR;
 
     const auto       CAIROSURFACE = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, bufferSize.x, bufferSize.y);
     const auto       CAIRO        = cairo_create(CAIROSURFACE);
@@ -580,24 +582,28 @@ void CHyprBar::draw(PHLMONITOR pMonitor, const float& a) {
 void CHyprBar::renderPass(PHLMONITOR pMonitor, const float& a) {
     const auto         PWINDOW = m_pWindow.lock();
 
-    static auto* const PCOLOR            = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_color")->getDataStaticPtr();
-    static auto* const PHEIGHT           = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_height")->getDataStaticPtr();
-    static auto* const PPRECEDENCE       = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_precedence_over_border")->getDataStaticPtr();
-    static auto* const PALIGNBUTTONS     = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_buttons_alignment")->getDataStaticPtr();
-    static auto* const PENABLETITLE      = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_title_enabled")->getDataStaticPtr();
-    static auto* const PENABLEBLUR       = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_blur")->getDataStaticPtr();
-    static auto* const PENABLEBLURGLOBAL = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "decoration:blur:enabled")->getDataStaticPtr();
-    static auto* const PINACTIVECOLOR    = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:inactive_button_color")->getDataStaticPtr();
+    static auto* const PCOLOR             = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_color")->getDataStaticPtr();
+    static auto* const PHEIGHT            = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_height")->getDataStaticPtr();
+    static auto* const PPRECEDENCE        = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_precedence_over_border")->getDataStaticPtr();
+    static auto* const PALIGNBUTTONS      = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_buttons_alignment")->getDataStaticPtr();
+    static auto* const PENABLETITLE       = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_title_enabled")->getDataStaticPtr();
+    static auto* const PENABLEBLUR        = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_blur")->getDataStaticPtr();
+    static auto* const PENABLEBLURGLOBAL  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "decoration:blur:enabled")->getDataStaticPtr();
+    static auto* const PINACTIVECOLOR     = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:inactive_button_color")->getDataStaticPtr();
+    static auto* const PBARINACTIVECOLOR  = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:bar_inactive_color")->getDataStaticPtr();
+    static auto* const PTEXTINACTIVECOLOR = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprbars:col.inactive_text")->getDataStaticPtr();
 
-    if (**PINACTIVECOLOR > 0) {
-        bool currentWindowFocus = PWINDOW == Desktop::focusState()->window();
-        if (currentWindowFocus != m_bWindowHasFocus) {
-            m_bWindowHasFocus = currentWindowFocus;
-            m_bButtonsDirty   = true;
-        }
+    bool currentWindowFocus = PWINDOW == Desktop::focusState()->window();
+    if (currentWindowFocus != m_bWindowHasFocus) {
+        m_bWindowHasFocus = currentWindowFocus;
+        if (**PINACTIVECOLOR > 0)
+            m_bButtonsDirty = true;
+        if (**PTEXTINACTIVECOLOR > 0)
+            m_bTitleColorChanged = true;
     }
 
-    const CHyprColor DEST_COLOR = m_bForcedBarColor.value_or(**PCOLOR);
+    const CHyprColor ACTIVE_BAR_COLOR = m_bForcedBarColor.value_or(**PCOLOR);
+    const CHyprColor DEST_COLOR       = (!m_bWindowHasFocus && **PBARINACTIVECOLOR > 0) ? CHyprColor(**PBARINACTIVECOLOR) : ACTIVE_BAR_COLOR;
     if (DEST_COLOR != m_cRealBarColor->goal())
         *m_cRealBarColor = DEST_COLOR;
 

--- a/hyprbars/main.cpp
+++ b/hyprbars/main.cpp
@@ -131,6 +131,8 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:enabled", Hyprlang::INT{1});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:icon_on_hover", Hyprlang::INT{0});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:inactive_button_color", Hyprlang::INT{0}); // unset
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:bar_inactive_color", Hyprlang::INT{0});
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:col.inactive_text", Hyprlang::INT{0});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprbars:on_double_click", Hyprlang::STRING{""});
 
     HyprlandAPI::addConfigKeyword(PHANDLE, "plugin:hyprbars:hyprbars-button", onNewButton, Hyprlang::SHandlerOptions{});


### PR DESCRIPTION
Adds support for text and bar colour for inactive windows and updates the readme with the corresponding config values