### PR TITLE
csgo-vulkan-fix: suppress deprecation warnings to fix build

### DIFF
--- a/csgo-vulkan-fix/CMakeLists.txt
+++ b/csgo-vulkan-fix/CMakeLists.txt
@@ -22,6 +22,7 @@ pkg_check_modules(deps REQUIRED IMPORTED_TARGET
     wayland-server
     xkbcommon
 )
+target_compile_options(csgo-vulkan-fix PRIVATE -Wno-deprecated-declarations)
 target_link_libraries(csgo-vulkan-fix PRIVATE rt PkgConfig::deps)
 
 install(TARGETS csgo-vulkan-fix)


### PR DESCRIPTION
Build was failing with:
```
$ make all
g++ -O2 -shared -fPIC -std=c++2b  --no-gnu-unique main.cpp -o csgo-vulkan-fix.so `pkg-config --cflags pixman-1 libdrm hyprland pangocairo libinput libudev wayland-server xkbcommon`
main.cpp: In function ‘PLUGIN_DESCRIPTION_INFO pluginInit(void*)’:
main.cpp:180:38: warning: ‘bool HyprlandAPI::addConfigKeyword(void*, const std::string&, Hyprlang::PCONFIGHANDLERFUNC, Hyprlang::SHandlerOptions)’ is deprecated [-Wdeprecated-declarations]
  180 |         HyprlandAPI::addConfigKeyword(
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
  181 |             PHANDLE, "vkfix-app",
      |             ~~~~~~~~~~~~~~~~~~~~~     
  182 |             [](const char* l, const char* r) -> Hyprlang::CParseResult {
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  183 |                 const std::string      str = r;
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  184 |                 CConstVarList          data(str, 0, ',', true);
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  185 | 
      |                                       
  186 |                 Hyprlang::CParseResult result;
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  187 | 
      |                                       
  188 |                 if (data.size() != 3) {
      |                 ~~~~~~~~~~~~~~~~~~~~~~~
  189 |                     result.setError("vkfix-app requires 3 params");
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  190 |                     return result;
      |                     ~~~~~~~~~~~~~~    
  191 |                 }
      |                 ~                     
  192 | 
      |                                       
  193 |                 try {
      |                 ~~~~~                 
  194 |                     SAppConfig config;
      |                     ~~~~~~~~~~~~~~~~~~
  195 |                     config.szClass = data[0];
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~
  196 |                     config.res     = Vector2D{std::stoi(std::string{data[1]}), std::stoi(std::string{data[2]})};
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  197 |                     g_appConfigs.emplace_back(std::move(config));
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  198 |                 } catch (std::exception& e) {
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  199 |                     result.setError("failed to parse line");
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  200 |                     return result;
      |                     ~~~~~~~~~~~~~~    
  201 |                 }
      |                 ~                     
  202 | 
      |                                       
  203 |                 return result;
      |                 ~~~~~~~~~~~~~~        
  204 |             },
      |             ~~                        
  205 |             Hyprlang::SHandlerOptions{});
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from globals.hpp:3,
                 from main.cpp:16:
/nix/store/vm0mlnq20z38xyk7d73q564x9lrr567i-hyprland-0.55.0+date=2026-05-09_ee58a51-dev/include/hyprland/src/plugins/PluginAPI.hpp:150:33: note: declared here
  150 |     APICALL [[deprecated]] bool addConfigKeyword(HANDLE handle, const std::string& name, Hyprlang::PCONFIGHANDLERFUNC fn, Hyprlang::SHandlerOptions opts);
      |                                 ^~~~~~~~~~~~~~~~
```