### PR TITLE
bars: fix fg_color not working with lua

### DIFF
--- a/hyprbars/main.cpp
+++ b/hyprbars/main.cpp
@@ -143,6 +143,7 @@ int newLuaButton(lua_State* L) {
         if (err.errorCode != Config::Lua::PARSE_ERROR_OK)
             return Config::Lua::Bindings::Internal::configError(L, "add_button: failed to parse fg_color");
 
+        button.userfg = true;
         button.fgcol = parser.parsed();
     }
 


### PR DESCRIPTION
Button fg_color doesn't work with lua config because userfg is never set to true. This PR fixes that.