### PR TITLE
borderspp: avoid adding multiple borders when reopening windows

### DIFF
--- a/borders-plus-plus/main.cpp
+++ b/borders-plus-plus/main.cpp
@@ -19,6 +19,9 @@ APICALL EXPORT std::string PLUGIN_API_VERSION() {
 }
 
 static void onNewWindow(PHLWINDOW window) {
+    if (std::ranges::any_of(window->m_windowDecorations, [](const auto& d) { return d->getDisplayName() == "Borders++"; }))
+        return;
+
     HyprlandAPI::addWindowDecoration(PHANDLE, window, makeUnique<CBordersPlusPlus>(window));
 }
 


### PR DESCRIPTION
In some apps (such as Steam), putting the app in background and reopening it causes another set of borders to be added to the window (see picture). This PR fixes this issue by ensuring windows have no more than 1 "Borders++" decoration.

<img width="118" height="121" alt="image" src="https://github.com/user-attachments/assets/5da785da-e052-46e8-88ef-4c5e0aab97b9" />
