### PR TITLE
hyprbars: add bar_text_weight config option

### DIFF
--- a/hyprbars/README.md
+++ b/hyprbars/README.md
@@ -34,6 +34,7 @@ plugin {
 `col.text` | color | bar's title text color
 `bar_title_enabled` | bool | whether to render the title | `true`
 `bar_text_size` | int | bar's title text font size | `10`
+`bar_text_weight` | font weight | bar's title text weight. Named (`thin`, `light`, `normal`, `medium`, `semibold`, `bold`, `ultrabold`, `heavy`, ...) or integer 100-1000 | `400`
 `bar_text_font` | str | bar's title text font | `Sans`
 `bar_text_align` | left, center | bar's title text alignment | `center`
 `bar_buttons_alignment` | right, left | bar's buttons alignment | `right`

--- a/hyprbars/barDeco.cpp
+++ b/hyprbars/barDeco.cpp
@@ -286,6 +286,7 @@ bool CHyprBar::doButtonPress(Config::INTEGER barPadding, Config::INTEGER barButt
 void CHyprBar::renderBarTitle(const Vector2D& bufferSize, const float scale) {
     const auto COLORVAL         = g_pGlobalState->config.textColor->value();
     const auto SIZE             = g_pGlobalState->config.barTextSize->value();
+    const auto WEIGHT           = g_pGlobalState->config.barTextWeight->value();
     const auto FONT             = g_pGlobalState->config.barTextFont->value();
     const auto ALIGN            = g_pGlobalState->config.barTextAlign->value();
     const auto BARPADDING       = g_pGlobalState->config.barPadding->value();
@@ -308,7 +309,7 @@ void CHyprBar::renderBarTitle(const Vector2D& bufferSize, const float scale) {
     }
 
     const CHyprColor COLOR = m_bForcedTitleColor.value_or(configColor(COLORVAL));
-    m_pTextTex             = g_pHyprRenderer->renderText(m_szLastTitle, COLOR, scaledSize, false, FONT, maxWidth);
+    m_pTextTex             = g_pHyprRenderer->renderText(m_szLastTitle, COLOR, scaledSize, false, FONT, maxWidth, WEIGHT.m_value);
 }
 
 size_t CHyprBar::getVisibleButtonCount(Config::INTEGER barButtonPadding, Config::INTEGER barPadding, const Vector2D& bufferSize, const float scale) {

--- a/hyprbars/globals.hpp
+++ b/hyprbars/globals.hpp
@@ -6,6 +6,7 @@
 #include <hyprland/src/config/values/types/IntValue.hpp>
 #include <hyprland/src/config/values/types/StringValue.hpp>
 #include <hyprland/src/config/values/types/ColorValue.hpp>
+#include <hyprland/src/config/values/types/FontWeightValue.hpp>
 
 inline HANDLE PHANDLE = nullptr;
 
@@ -29,13 +30,14 @@ struct SGlobalState {
     uint32_t                  titleColorRuleIdx = 0;
 
     struct {
-        SP<Config::Values::CColorValue>  barColor, textColor, inactiveButtonColor;
-        SP<Config::Values::CIntValue>    barHeight;
-        SP<Config::Values::CIntValue>    barTextSize;
-        SP<Config::Values::CIntValue>    barPadding;
-        SP<Config::Values::CIntValue>    barButtonPadding;
-        SP<Config::Values::CBoolValue>   barBlur, barTitleEnabled, barPartOfWindow, barPrecedenceOverBorder, enabled, iconOnHover;
-        SP<Config::Values::CStringValue> barTextFont, barTextAlign, barButtonsAlignment, onDoubleClick;
+        SP<Config::Values::CColorValue>      barColor, textColor, inactiveButtonColor;
+        SP<Config::Values::CIntValue>        barHeight;
+        SP<Config::Values::CIntValue>        barTextSize;
+        SP<Config::Values::CFontWeightValue> barTextWeight;
+        SP<Config::Values::CIntValue>        barPadding;
+        SP<Config::Values::CIntValue>        barButtonPadding;
+        SP<Config::Values::CBoolValue>       barBlur, barTitleEnabled, barPartOfWindow, barPrecedenceOverBorder, enabled, iconOnHover;
+        SP<Config::Values::CStringValue>     barTextFont, barTextAlign, barButtonsAlignment, onDoubleClick;
     } config;
 };
 

--- a/hyprbars/main.cpp
+++ b/hyprbars/main.cpp
@@ -215,6 +215,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
         "plugin:hyprbars:inactive_button_color", "Change the inactive button's color. 0x00000000 means unset", 0x00000000);
     g_pGlobalState->config.barHeight       = makeShared<Config::Values::CIntValue>("plugin:hyprbars:bar_height", "Change the bar's height", 15);
     g_pGlobalState->config.barTextSize     = makeShared<Config::Values::CIntValue>("plugin:hyprbars:bar_text_size", "Change the bar's text size", 10);
+    g_pGlobalState->config.barTextWeight   = makeShared<Config::Values::CFontWeightValue>("plugin:hyprbars:bar_text_weight", "Bar's title text weight (e.g. \"bold\" or an integer 100-1000)", 400);
     g_pGlobalState->config.barTitleEnabled = makeShared<Config::Values::CBoolValue>("plugin:hyprbars:bar_title_enabled", "Whether to enable titles in the bar", true);
     g_pGlobalState->config.barBlur         = makeShared<Config::Values::CBoolValue>("plugin:hyprbars:bar_blur", "Whether to enable blur of the bar", false);
     g_pGlobalState->config.barTextFont     = makeShared<Config::Values::CStringValue>("plugin:hyprbars:bar_text_font", "Bar's text font", "Sans");
@@ -235,6 +236,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     HyprlandAPI::addConfigValueV2(PHANDLE, g_pGlobalState->config.inactiveButtonColor);
     HyprlandAPI::addConfigValueV2(PHANDLE, g_pGlobalState->config.barHeight);
     HyprlandAPI::addConfigValueV2(PHANDLE, g_pGlobalState->config.barTextSize);
+    HyprlandAPI::addConfigValueV2(PHANDLE, g_pGlobalState->config.barTextWeight);
     HyprlandAPI::addConfigValueV2(PHANDLE, g_pGlobalState->config.barTitleEnabled);
     HyprlandAPI::addConfigValueV2(PHANDLE, g_pGlobalState->config.barBlur);
     HyprlandAPI::addConfigValueV2(PHANDLE, g_pGlobalState->config.barTextFont);


### PR DESCRIPTION
## Summary

Hyprland's `IHyprRenderer::renderText()` accepts a Pango weight parameter, but hyprbars never passed one — so title text always renders at weight 400 (Regular).

This is a problem for variable fonts where every weight shares one family name (e.g. Adwaita Sans). Setting `bar_text_font = "Adwaita Sans Bold"` doesn't work because Hyprland calls `pango_font_description_set_family_static()`, which ignores style tokens embedded in the family string. The user has no way to get Bold/ExtraBold/etc. titles without resorting to fontconfig aliases.

This PR adds a `bar_text_weight` config option (Pango weight, 100–1000, default `400`) and plumbs it through to `renderText()`.

## Changes

- `globals.hpp`: add `barTextWeight` to the config struct.
- `main.cpp`: register `plugin:hyprbars:bar_text_weight` (default 400).
- `barDeco.cpp`: read it and pass as the `weight` arg to `renderText()`.
- `README.md`: document the new option.

Diff is +6/-1.

## Test plan

- [x] Built locally against Hyprland 0.55.0 headers (via `hyprpm update`).
- [x] Loaded into running Hyprland; verified `bar_text_weight = 800` renders ExtraBold for "Adwaita Sans" titles, where the unpatched build rendered Regular.
- [x] Verified default (400) preserves existing behavior — omitting the option produces identical output to the unpatched build.