### PR TITLE
[hyprbars] (firefox) xdg-popup swallowing over hyprbars

### DIFF
--- a/hyprbars/barDeco.cpp
+++ b/hyprbars/barDeco.cpp
@@ -221,6 +221,10 @@ void CHyprBar::handleDownEvent(Event::SCallbackInfo& info, std::optional<ITouch:
         return;
     }
 
+    // don't swallow clicks meant for xdg popups (e.g. context menus) overlapping the bar
+    if (PWINDOW->hasPopupAt(COORDS + assignedBoxGlobal().pos()))
+        return;
+
     if (Desktop::focusState()->window() != PWINDOW)
         Desktop::focusState()->fullWindowFocus(PWINDOW, Desktop::FOCUS_REASON_CLICK);
 


### PR DESCRIPTION
Prevent swallowing clicks meant for xdg popups (e.g. context menus) overlapping ontop of the hyprbars bar.

Whenever I try to rightclick youtube videos on youtube.com in firefox, an xdg-popup appears over the hyprbars.
I can old left click that popup if it does not overlappingly intersect over the hyprbars.
<img width="1712" height="503" alt="xdg-popup-bug" src="https://github.com/user-attachments/assets/afa70c78-3445-4be0-8299-0420d4a84cda" />
