### PR TITLE
hyprbars: ignore input while disabled

### DIFF
--- a/hyprbars/barDeco.cpp
+++ b/hyprbars/barDeco.cpp
@@ -86,7 +86,7 @@ std::string CHyprBar::getDisplayName() {
 }
 
 bool CHyprBar::inputIsValid() {
-    if (m_hidden)
+    if (!g_pGlobalState->config.enabled->value() || m_hidden)
         return false;
 
     if (g_pSeatManager->m_seatGrab && !g_pSeatManager->m_seatGrab->accepts(m_pWindow->wlSurface()->resource()))


### PR DESCRIPTION
When `plugin:hyprbars:enabled` is false, the invisible bar still intercepts clicks and drags.

Reject input when the plugin is disabled.

Ref #690

Validation:
- `git diff --check`
- `clang-format --dry-run --Werror hyprbars/barDeco.cpp`

<!-- crq:skip-autoreview -->