### PR TITLE
hyprbars: end the drag when the button is released over a layer surface

### DIFF
--- a/hyprbars/barDeco.cpp
+++ b/hyprbars/barDeco.cpp
@@ -125,10 +125,25 @@ bool CHyprBar::inputIsValid() {
 }
 
 void CHyprBar::onMouseButton(Event::SCallbackInfo& info, IPointer::SButtonEvent e) {
+    const bool RELEASE = e.state != WL_POINTER_BUTTON_STATE_PRESSED;
+
+    // A release that closes an interaction we swallowed has to be handled even when
+    // inputIsValid() would reject it now. Dragging a window by its bar takes the
+    // pointer wherever the user goes, and a top or overlay layer surface under it (a
+    // status bar, a dock) makes inputIsValid() false. Dropping the release there skips
+    // handleUpEvent(), the only caller of endDragTarget(): the drag stays alive and the
+    // window keeps following the pointer until the next click elsewhere. Hyprland
+    // cannot clean up after us either, since we cancelled the press and the button
+    // never reached m_currentlyHeldButtons, so its own release path returns early.
+    if (RELEASE && (m_bCancelledDown || m_bDraggingThis)) {
+        handleUpEvent(info);
+        return;
+    }
+
     if (!inputIsValid())
         return;
 
-    if (e.state != WL_POINTER_BUTTON_STATE_PRESSED) {
+    if (RELEASE) {
         handleUpEvent(info);
         return;
     }
@@ -249,7 +264,9 @@ void CHyprBar::handleDownEvent(Event::SCallbackInfo& info, std::optional<ITouch:
 }
 
 void CHyprBar::handleUpEvent(Event::SCallbackInfo& info) {
-    if (m_pWindow.lock() != Desktop::focusState()->window())
+    // A drag we started has to end no matter who holds focus now, or it outlives the
+    // button press.
+    if (m_pWindow.lock() != Desktop::focusState()->window() && !m_bDraggingThis)
         return;
 
     if (m_bCancelledDown)


### PR DESCRIPTION
### What happens

Grab a window by its hyprbar and drag it to the top of the screen, where a
layer-shell status bar lives. Let go of the button. The window keeps following
the pointer, as if the button were still held, until you click somewhere else.

Same thing at the bottom edge if you have a dock. Any `zwlr_layer_shell` surface
on the `TOP` or `OVERLAY` layer triggers it, so most bar/dock setups hit this.

### Why

`CHyprBar::onMouseButton()` starts with `if (!inputIsValid()) return;`, and
`inputIsValid()` returns false whenever `layerSurfaceAt()` finds a top or overlay
layer surface under the pointer. `handleUpEvent()` is the only caller of
`endDragTarget()`, so a release over such a surface is dropped and the drag is
never finished.

Hyprland cannot clean up after us either: we set `info.cancelled` on the press,
so `CInputManager::onMouseButton()` returned before pushing the button into
`m_currentlyHeldButtons`, and its release path bails out on the missing entry
before it could end the drag.

The check exists so the bar does not steal input meant for a bar or a dock that
overlaps it. That reasoning applies to *starting* an interaction, not to
finishing one we already own.

### The fix

Handle the release before `inputIsValid()` when we swallowed the matching press
(`m_bCancelledDown`) or are already dragging (`m_bDraggingThis`). Presses still
go through the check unchanged, so nothing new is stolen from layer surfaces.

`handleUpEvent()` also returned early when the bar's window was no longer
focused, which leaks the drag the same way; it now finishes a drag it started
regardless of focus.

### Testing

Reproduced and fixed on Hyprland 0.56.2 with a Quickshell status bar
(`zwlr_layer_shell`, `TOP` layer, 26px tall, at the top of the screen). I am
running the equivalent patch applied to `7644cec` (the `hyprpm.toml` pin for
0.56.2): drags released over the bar now end on the release, and drags released
away from any layer surface behave exactly as before.

This branch is on `main`, which targets Hyprland git rather than 0.56.2, so I
could not build this exact commit locally — the two hunks are identical in both
revisions.
